### PR TITLE
Only use jq if jq is available

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -149,7 +149,7 @@ func LoadBuildpackYAML(appRoot string) (BuildpackYAML, error) {
 }
 
 func memoryAvailable() string {
-	return `if ! which jq > /dev/null; then
+	return `if which jq > /dev/null; then
 	MEMORY_AVAILABLE="$(echo $VCAP_APPLICATION | jq .limits.mem)"
 fi
 


### PR DESCRIPTION
Seeing errors in our logs on startup because `jq` is not installed in bionic.

```
/layers/org.cloudfoundry.node-engine/node/profile.d/0_memory_available.sh: line 2: jq: command not found
```
