### PR TITLE
Uses buildpack.toml config in integration suite

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/paketo-buildpacks/node-engine
 go 1.13
 
 require (
+	github.com/BurntSushi/toml v0.3.1
 	github.com/Masterminds/semver v1.5.0
 	github.com/onsi/gomega v1.10.1
 	github.com/paketo-buildpacks/occam v0.0.12

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -2,11 +2,13 @@ package integration
 
 import (
 	"bytes"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/BurntSushi/toml"
 	"github.com/paketo-buildpacks/occam"
 	"github.com/paketo-buildpacks/packit/pexec"
 	"github.com/sclevine/spec"
@@ -20,6 +22,13 @@ var (
 	offlineNodeBuildpack string
 	root                 string
 	version              string
+
+	config struct {
+		Buildpack struct {
+			ID   string
+			Name string
+		}
+	}
 )
 
 func TestIntegration(t *testing.T) {
@@ -28,6 +37,13 @@ func TestIntegration(t *testing.T) {
 	var err error
 	root, err = filepath.Abs("./..")
 	Expect(err).ToNot(HaveOccurred())
+
+	file, err := os.Open("../buildpack.toml")
+	Expect(err).NotTo(HaveOccurred())
+	defer file.Close()
+
+	_, err = toml.DecodeReader(file, &config)
+	Expect(err).NotTo(HaveOccurred())
 
 	buildpackStore := occam.NewBuildpackStore()
 

--- a/integration/reuse_layer_rebuild_test.go
+++ b/integration/reuse_layer_rebuild_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/paketo-buildpacks/occam"
@@ -77,11 +78,11 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			imageIDs[firstImage.ID] = struct{}{}
 
 			Expect(firstImage.Buildpacks).To(HaveLen(1))
-			Expect(firstImage.Buildpacks[0].Key).To(Equal("paketo-buildpacks/node-engine"))
+			Expect(firstImage.Buildpacks[0].Key).To(Equal(config.Buildpack.ID))
 			Expect(firstImage.Buildpacks[0].Layers).To(HaveKey("node"))
 
 			Expect(logs).To(ContainLines(
-				fmt.Sprintf("Node Engine Buildpack %s", version),
+				fmt.Sprintf("%s %s", config.Buildpack.Name, version),
 				"  Resolving Node Engine version",
 				"    Candidate version sources (in priority order):",
 				"      buildpack.yml -> \"~10\"",
@@ -94,7 +95,7 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 				"",
 				"  Configuring environment",
 				`    NODE_ENV     -> "production"`,
-				`    NODE_HOME    -> "/layers/paketo-buildpacks_node-engine/node"`,
+				fmt.Sprintf(`    NODE_HOME    -> "/layers/%s/node"`, strings.ReplaceAll(config.Buildpack.ID, "/", "_")),
 				`    NODE_VERBOSE -> "false"`,
 				"",
 				"    Writing profile.d/0_memory_available.sh",
@@ -119,18 +120,18 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			imageIDs[secondImage.ID] = struct{}{}
 
 			Expect(secondImage.Buildpacks).To(HaveLen(1))
-			Expect(secondImage.Buildpacks[0].Key).To(Equal("paketo-buildpacks/node-engine"))
+			Expect(secondImage.Buildpacks[0].Key).To(Equal(config.Buildpack.ID))
 			Expect(secondImage.Buildpacks[0].Layers).To(HaveKey("node"))
 
 			Expect(logs).To(ContainLines(
-				fmt.Sprintf("Node Engine Buildpack %s", version),
+				fmt.Sprintf("%s %s", config.Buildpack.Name, version),
 				"  Resolving Node Engine version",
 				"    Candidate version sources (in priority order):",
 				"      buildpack.yml -> \"~10\"",
 				"",
 				MatchRegexp(`    Selected Node Engine version \(using buildpack\.yml\): 10\.\d+\.\d+`),
 				"",
-				"  Reusing cached layer /layers/paketo-buildpacks_node-engine/node",
+				fmt.Sprintf("  Reusing cached layer /layers/%s/node", strings.ReplaceAll(config.Buildpack.ID, "/", "_")),
 			))
 
 			secondContainer, err = docker.Container.Run.WithMemory("128m").WithCommand("node server.js").Execute(secondImage.ID)
@@ -182,11 +183,11 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			imageIDs[firstImage.ID] = struct{}{}
 
 			Expect(firstImage.Buildpacks).To(HaveLen(1))
-			Expect(firstImage.Buildpacks[0].Key).To(Equal("paketo-buildpacks/node-engine"))
+			Expect(firstImage.Buildpacks[0].Key).To(Equal(config.Buildpack.ID))
 			Expect(firstImage.Buildpacks[0].Layers).To(HaveKey("node"))
 
 			Expect(logs).To(ContainLines(
-				fmt.Sprintf("Node Engine Buildpack %s", version),
+				fmt.Sprintf("%s %s", config.Buildpack.Name, version),
 				"  Resolving Node Engine version",
 				"    Candidate version sources (in priority order):",
 				"      buildpack.yml -> \"~10\"",
@@ -199,7 +200,7 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 				"",
 				"  Configuring environment",
 				`    NODE_ENV     -> "production"`,
-				`    NODE_HOME    -> "/layers/paketo-buildpacks_node-engine/node"`,
+				fmt.Sprintf(`    NODE_HOME    -> "/layers/%s/node"`, strings.ReplaceAll(config.Buildpack.ID, "/", "_")),
 				`    NODE_VERBOSE -> "false"`,
 				"",
 				"    Writing profile.d/0_memory_available.sh",
@@ -227,11 +228,11 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			imageIDs[secondImage.ID] = struct{}{}
 
 			Expect(secondImage.Buildpacks).To(HaveLen(1))
-			Expect(secondImage.Buildpacks[0].Key).To(Equal("paketo-buildpacks/node-engine"))
+			Expect(secondImage.Buildpacks[0].Key).To(Equal(config.Buildpack.ID))
 			Expect(secondImage.Buildpacks[0].Layers).To(HaveKey("node"))
 
 			Expect(logs).To(ContainLines(
-				fmt.Sprintf("Node Engine Buildpack %s", version),
+				fmt.Sprintf("%s %s", config.Buildpack.Name, version),
 				"  Resolving Node Engine version",
 				"    Candidate version sources (in priority order):",
 				"      buildpack.yml -> \"~12\"",
@@ -244,7 +245,7 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 				"",
 				"  Configuring environment",
 				`    NODE_ENV     -> "production"`,
-				`    NODE_HOME    -> "/layers/paketo-buildpacks_node-engine/node"`,
+				fmt.Sprintf(`    NODE_HOME    -> "/layers/%s/node"`, strings.ReplaceAll(config.Buildpack.ID, "/", "_")),
 				`    NODE_VERBOSE -> "false"`,
 				"",
 				"    Writing profile.d/0_memory_available.sh",


### PR DESCRIPTION
Instead of hardcoding these values, we are parameterizing them and reading them from the buildpack.toml so that if they change, the test suite does not need to change.