### PR TITLE
Do not auto mark launch=true for node layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ file that looks like the following:
     # their build phase. If you are writing a buildpack that needs to run Node
     # during its build process, this flag should be set to true.
     build = true
+
+    # Setting the launch flag to true will ensure that the Node Engine
+    # dependency is available on the $PATH for the running application. If you are
+    # writing an application that needs to run node at runtime, this flag should
+    # be set to true.
+    launch = true
 ```
 
 Or they can require both `node` and `npm` using a Build Plan that looks like the following:
@@ -68,6 +74,12 @@ Or they can require both `node` and `npm` using a Build Plan that looks like the
     # their build phase. If you are writing a buildpack that needs to run Node
     # during its build process, this flag should be set to true.
     build = true
+
+    # Setting the launch flag to true will ensure that the Node Engine
+    # dependency is available on the $PATH for the running application. If you are
+    # writing an application that needs to run node at runtime, this flag should
+    # be set to true.
+    launch = true
 
 [[requires]]
 

--- a/build.go
+++ b/build.go
@@ -40,6 +40,7 @@ func Build(entries EntryResolver, dependencies DependencyManager, environment En
 
 		var dependency postal.Dependency
 		var err error
+
 		version, _ := entry.Metadata["version"].(string)
 		dependency, err = dependencies.Resolve(filepath.Join(context.CNBPath, "buildpack.toml"), entry.Name, version, context.Stack)
 
@@ -49,11 +50,12 @@ func Build(entries EntryResolver, dependencies DependencyManager, environment En
 
 		logger.SelectedDependency(entry, dependency, clock.Now())
 
-		nodeLayer, err := context.Layers.Get(Node, packit.LaunchLayer)
+		nodeLayer, err := context.Layers.Get(Node)
 		if err != nil {
 			return packit.BuildResult{}, err
 		}
 
+		nodeLayer.Launch = entry.Metadata["launch"] == true
 		nodeLayer.Build = entry.Metadata["build"] == true
 		nodeLayer.Cache = entry.Metadata["build"] == true
 

--- a/build_test.go
+++ b/build_test.go
@@ -90,8 +90,11 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				{
 					Name: "node",
 					Metadata: map[string]interface{}{
-						"version":        "~10",
-						"version-source": "buildpack.yml",
+						"name":    "node-dependency-name",
+						"sha256":  "node-dependency-sha",
+						"stacks":  []string{"some-stack"},
+						"uri":     "node-dependency-uri",
+						"version": "~10",
 					},
 				},
 			},
@@ -136,8 +139,11 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					{
 						Name: "node",
 						Metadata: map[string]interface{}{
-							"version":        "~10",
-							"version-source": "buildpack.yml",
+							"name":    "node-dependency-name",
+							"sha256":  "node-dependency-sha",
+							"stacks":  []string{"some-stack"},
+							"uri":     "node-dependency-uri",
+							"version": "~10",
 						},
 					},
 				},
@@ -261,10 +267,11 @@ nodejs:
 					{
 						Name: "node",
 						Metadata: map[string]interface{}{
-							"version":        "~10",
-							"version-source": "buildpack.yml",
-							"launch":         true,
-							"build":          true,
+							"name":    "node-dependency-name",
+							"sha256":  "node-dependency-sha",
+							"stacks":  []string{"some-stack"},
+							"uri":     "node-dependency-uri",
+							"version": "~10",
 						},
 					},
 				},
@@ -302,10 +309,11 @@ nodejs:
 						{
 							Name: "node",
 							Metadata: map[string]interface{}{
-								"version":        "~10",
-								"version-source": "buildpack.yml",
-								"launch":         true,
-								"build":          true,
+								"name":    "node-dependency-name",
+								"sha256":  "node-dependency-sha",
+								"stacks":  []string{"some-stack"},
+								"uri":     "node-dependency-uri",
+								"version": "~10",
 							},
 						},
 					},

--- a/build_test.go
+++ b/build_test.go
@@ -150,7 +150,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					BuildEnv:  packit.Environment{},
 					LaunchEnv: packit.Environment{},
 					Build:     false,
-					Launch:    true,
+					Launch:    false,
 					Cache:     false,
 					Metadata: map[string]interface{}{
 						nodeengine.DepKey: "",
@@ -238,7 +238,7 @@ nodejs:
 		})
 	})
 
-	context("when the build plan entry includes the build flag", func() {
+	context("when the build plan entry includes the build, launch flags", func() {
 		var workingDir string
 
 		it.Before(func() {
@@ -251,6 +251,7 @@ nodejs:
 				Metadata: map[string]interface{}{
 					"version":        "~10",
 					"version-source": "buildpack.yml",
+					"launch":         true,
 					"build":          true,
 				},
 			}
@@ -262,6 +263,7 @@ nodejs:
 						Metadata: map[string]interface{}{
 							"version":        "~10",
 							"version-source": "buildpack.yml",
+							"launch":         true,
 							"build":          true,
 						},
 					},
@@ -273,7 +275,7 @@ nodejs:
 			Expect(os.RemoveAll(workingDir)).To(Succeed())
 		})
 
-		it("marks the node layer as cached", func() {
+		it("marks the node layer as build, cached and launch", func() {
 			result, err := build(packit.BuildContext{
 				CNBPath:    cnbDir,
 				Stack:      "some-stack",
@@ -285,6 +287,7 @@ nodejs:
 							Metadata: map[string]interface{}{
 								"version":        "~10",
 								"version-source": "buildpack.yml",
+								"launch":         true,
 								"build":          true,
 							},
 						},
@@ -301,6 +304,7 @@ nodejs:
 							Metadata: map[string]interface{}{
 								"version":        "~10",
 								"version-source": "buildpack.yml",
+								"launch":         true,
 								"build":          true,
 							},
 						},
@@ -413,7 +417,7 @@ nodejs:
 						BuildEnv:  packit.Environment{},
 						LaunchEnv: packit.Environment{},
 						Build:     false,
-						Launch:    true,
+						Launch:    false,
 						Cache:     false,
 						Metadata: map[string]interface{}{
 							nodeengine.DepKey: "",

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,7 @@ github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/gabriel-vasile/mimetype v1.1.1 h1:qbN9MPuRf3bstHu9zkI9jDWNfH//9+9kHxr9oRBBBOA=
 github.com/gabriel-vasile/mimetype v1.1.1/go.mod h1:6CDPel/o/3/s4+bp6kIbsWATq8pmgOisOPG40CJa6To=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
@@ -70,17 +71,12 @@ github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108
 github.com/onsi/ginkgo v1.13.0 h1:M76yO2HkZASFjXL0HSoZJ1AYEmQxNJmY41Jx1zNUq1Y=
 github.com/onsi/ginkgo v1.13.0/go.mod h1:+REjRxOmWfHCjfv9TTWB1jD1Frx4XydAD3zm1lskyM0=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
-github.com/onsi/gomega v1.10.1 h1:o0+MgICZLuZ7xjH7Vx6zS/zcu93/BEp1VwkIW1mEXCE=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.2 h1:aY/nuoWlKJud2J6U0E3NWsjlg+0GtwXxgEqthRdzlcs=
 github.com/onsi/gomega v1.10.2/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
-github.com/paketo-buildpacks/occam v0.0.17 h1:djTYtqfREwbTy+KlwscOUjN9ZIPld1uP3sTw4Fdr0L0=
-github.com/paketo-buildpacks/occam v0.0.17/go.mod h1:9TFuRmC3OB8DlaBdd0hGPZQidnsmGmUlnLQTrltZB5Q=
 github.com/paketo-buildpacks/occam v0.0.18 h1:0n3ew3aLyk/CjZJY+QsW6UTS1d7k6seDylABnZwUuig=
 github.com/paketo-buildpacks/occam v0.0.18/go.mod h1:+QD+nyd/F1Ky+MmyxslDWio4cJCRiGXFVShVbteHr7U=
 github.com/paketo-buildpacks/packit v0.1.0/go.mod h1:b40wtWWAcgB47+vYGDD9KKhzOtBjI8KPqGxwGvV+XNs=
-github.com/paketo-buildpacks/packit v0.2.2/go.mod h1:b40wtWWAcgB47+vYGDD9KKhzOtBjI8KPqGxwGvV+XNs=
-github.com/paketo-buildpacks/packit v0.2.7 h1:KYv4MBU4JnTDE3P5udCskjQFbh668Gbxa6Bbe/582Uc=
 github.com/paketo-buildpacks/packit v0.2.7/go.mod h1:DO2CSp/uF+cn+9pk2zE+Y7ZpA99PPi/pBNYc2p4ZRjk=
 github.com/paketo-buildpacks/packit v0.2.8 h1:wGUsV7cO4UfsuKE/HXPp+cu+DQFolyao94iP5iG1Ez4=
 github.com/paketo-buildpacks/packit v0.2.8/go.mod h1:DeB8IvScMQVgO6c4J8IOeJglorhiiZa9StbgAN9rs/k=
@@ -88,7 +84,6 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=
 github.com/sclevine/spec v1.4.0 h1:z/Q9idDcay5m5irkZ28M7PtQM4aOISzOpj4bUPkDee8=
 github.com/sclevine/spec v1.4.0/go.mod h1:LvpgJaFyvQzRvc1kaDs0bulYwzC70PbiYjC4QnFHkOM=
-github.com/ulikunitz/xz v0.5.7 h1:YvTNdFzX6+W5m9msiYg/zpkSURPPtOlzbqYjrFn7Yt4=
 github.com/ulikunitz/xz v0.5.7/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.8 h1:ERv8V6GKqVi23rgu5cj9pVfVzJbOqAY2Ntl88O6c2nQ=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=

--- a/integration/logging_test.go
+++ b/integration/logging_test.go
@@ -56,7 +56,10 @@ func testLogging(t *testing.T, context spec.G, it spec.S) {
 			var logs fmt.Stringer
 			image, logs, err = pack.WithNoColor().Build.
 				WithNoPull().
-				WithBuildpacks(nodeBuildpack).
+				WithBuildpacks(
+					nodeBuildpack,
+					buildPlanBuildpack,
+				).
 				Execute(name, source)
 			Expect(err).ToNot(HaveOccurred(), logs.String)
 
@@ -65,6 +68,7 @@ func testLogging(t *testing.T, context spec.G, it spec.S) {
 				"  Resolving Node Engine version",
 				"    Candidate version sources (in priority order):",
 				"      buildpack.yml -> \"~10\"",
+				"      <unknown>     -> \"*\"",
 				"",
 				MatchRegexp(`    Selected Node Engine version \(using buildpack\.yml\): 10\.\d+\.\d+`),
 				"",
@@ -159,7 +163,10 @@ api = "0.2"
 
 				image, logs, err = pack.WithNoColor().Build.
 					WithNoPull().
-					WithBuildpacks(deprecatedDepNodeBuildpack).
+					WithBuildpacks(
+						deprecatedDepNodeBuildpack,
+						buildPlanBuildpack,
+					).
 					Execute(name, source)
 				Expect(err).ToNot(HaveOccurred(), logs.String)
 

--- a/integration/offline_test.go
+++ b/integration/offline_test.go
@@ -57,7 +57,10 @@ func testOffline(t *testing.T, context spec.G, it spec.S) {
 			var logs fmt.Stringer
 			image, logs, err = pack.WithNoColor().Build.
 				WithNoPull().
-				WithBuildpacks(offlineNodeBuildpack).
+				WithBuildpacks(
+					offlineNodeBuildpack,
+					buildPlanBuildpack,
+				).
 				WithNetwork("none").
 				Execute(name, source)
 

--- a/integration/optimize_memory_test.go
+++ b/integration/optimize_memory_test.go
@@ -53,7 +53,10 @@ func testOptimizeMemory(t *testing.T, context spec.G, it spec.S) {
 		var logs fmt.Stringer
 		image, logs, err = pack.WithNoColor().Build.
 			WithNoPull().
-			WithBuildpacks(nodeBuildpack).
+			WithBuildpacks(
+				nodeBuildpack,
+				buildPlanBuildpack,
+			).
 			Execute(name, source)
 
 		Expect(err).NotTo(HaveOccurred())

--- a/integration/reuse_layer_rebuild_test.go
+++ b/integration/reuse_layer_rebuild_test.go
@@ -71,13 +71,16 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 
 			firstImage, logs, err = pack.WithNoColor().Build.
 				WithNoPull().
-				WithBuildpacks(nodeBuildpack).
+				WithBuildpacks(
+					nodeBuildpack,
+					buildPlanBuildpack,
+				).
 				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred())
 
 			imageIDs[firstImage.ID] = struct{}{}
 
-			Expect(firstImage.Buildpacks).To(HaveLen(1))
+			Expect(firstImage.Buildpacks).To(HaveLen(2))
 			Expect(firstImage.Buildpacks[0].Key).To(Equal(config.Buildpack.ID))
 			Expect(firstImage.Buildpacks[0].Layers).To(HaveKey("node"))
 
@@ -86,6 +89,7 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 				"  Resolving Node Engine version",
 				"    Candidate version sources (in priority order):",
 				"      buildpack.yml -> \"~10\"",
+				"      <unknown>     -> \"*\"",
 				"",
 				MatchRegexp(`    Selected Node Engine version \(using buildpack\.yml\): 10\.\d+\.\d+`),
 				"",
@@ -113,13 +117,16 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			// Second pack build
 			secondImage, logs, err = pack.WithNoColor().Build.
 				WithNoPull().
-				WithBuildpacks(nodeBuildpack).
+				WithBuildpacks(
+					nodeBuildpack,
+					buildPlanBuildpack,
+				).
 				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred())
 
 			imageIDs[secondImage.ID] = struct{}{}
 
-			Expect(secondImage.Buildpacks).To(HaveLen(1))
+			Expect(secondImage.Buildpacks).To(HaveLen(2))
 			Expect(secondImage.Buildpacks[0].Key).To(Equal(config.Buildpack.ID))
 			Expect(secondImage.Buildpacks[0].Layers).To(HaveKey("node"))
 
@@ -128,6 +135,7 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 				"  Resolving Node Engine version",
 				"    Candidate version sources (in priority order):",
 				"      buildpack.yml -> \"~10\"",
+				"      <unknown>     -> \"*\"",
 				"",
 				MatchRegexp(`    Selected Node Engine version \(using buildpack\.yml\): 10\.\d+\.\d+`),
 				"",
@@ -170,13 +178,16 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 
 			firstImage, logs, err = pack.WithNoColor().Build.
 				WithNoPull().
-				WithBuildpacks(nodeBuildpack).
+				WithBuildpacks(
+					nodeBuildpack,
+					buildPlanBuildpack,
+				).
 				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred())
 
 			imageIDs[firstImage.ID] = struct{}{}
 
-			Expect(firstImage.Buildpacks).To(HaveLen(1))
+			Expect(firstImage.Buildpacks).To(HaveLen(2))
 			Expect(firstImage.Buildpacks[0].Key).To(Equal(config.Buildpack.ID))
 			Expect(firstImage.Buildpacks[0].Layers).To(HaveKey("node"))
 
@@ -185,6 +196,7 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 				"  Resolving Node Engine version",
 				"    Candidate version sources (in priority order):",
 				"      buildpack.yml -> \"~10\"",
+				"      <unknown>     -> \"*\"",
 				"",
 				MatchRegexp(`    Selected Node Engine version \(using buildpack\.yml\): 10\.\d+\.\d+`),
 				"",
@@ -218,13 +230,16 @@ nodejs:
 			// Second pack build
 			secondImage, logs, err = pack.WithNoColor().Build.
 				WithNoPull().
-				WithBuildpacks(nodeBuildpack).
+				WithBuildpacks(
+					nodeBuildpack,
+					buildPlanBuildpack,
+				).
 				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred())
 
 			imageIDs[secondImage.ID] = struct{}{}
 
-			Expect(secondImage.Buildpacks).To(HaveLen(1))
+			Expect(secondImage.Buildpacks).To(HaveLen(2))
 			Expect(secondImage.Buildpacks[0].Key).To(Equal(config.Buildpack.ID))
 			Expect(secondImage.Buildpacks[0].Layers).To(HaveKey("node"))
 
@@ -233,6 +248,7 @@ nodejs:
 				"  Resolving Node Engine version",
 				"    Candidate version sources (in priority order):",
 				"      buildpack.yml -> \"~12\"",
+				"      <unknown>     -> \"*\"",
 				"",
 				MatchRegexp(`    Selected Node Engine version \(using buildpack\.yml\): 12\.\d+\.\d+`),
 				"",

--- a/integration/testdata/optimize_memory/plan.toml
+++ b/integration/testdata/optimize_memory/plan.toml
@@ -1,0 +1,5 @@
+[[requires]]
+  name = "node"
+
+  [requires.metadata]
+    launch = true

--- a/integration/testdata/simple_app/plan.toml
+++ b/integration/testdata/simple_app/plan.toml
@@ -1,0 +1,5 @@
+[[requires]]
+  name = "node"
+
+  [requires.metadata]
+    launch = true

--- a/plan_entry_resolver.go
+++ b/plan_entry_resolver.go
@@ -54,6 +54,10 @@ func (r PlanEntryResolver) Resolve(entries []packit.BuildpackPlanEntry) packit.B
 		if entry.Metadata["build"] == true {
 			chosenEntry.Metadata["build"] = true
 		}
+
+		if entry.Metadata["launch"] == true {
+			chosenEntry.Metadata["launch"] = true
+		}
 	}
 
 	r.logger.Candidates(filteredEntries)


### PR DESCRIPTION
Read the buildpack plan and mark layers accordingly for export.
Also, use some real BOM metadata values in unit test.

Makes the buildpack fully compliant to [Nodejs RFC 0001](https://github.com/paketo-buildpacks/nodejs/blob/v0.0.7/rfcs/0001-buildpacks-architecture.md)




Fixes #104
