### PR TITLE
Use new scribe.emitter generic logger for EOS logging

### DIFF
--- a/log_emitter.go
+++ b/log_emitter.go
@@ -3,45 +3,21 @@ package nodeengine
 import (
 	"io"
 	"strconv"
-	"time"
 
 	"github.com/paketo-buildpacks/packit"
-	"github.com/paketo-buildpacks/packit/postal"
 	"github.com/paketo-buildpacks/packit/scribe"
 )
 
 type LogEmitter struct {
-	// Logger is embedded and therefore delegates all of its functions to the
+	// Emitter is embedded and therefore delegates all of its functions to the
 	// LogEmitter.
-	scribe.Logger
+	scribe.Emitter
 }
 
 func NewLogEmitter(output io.Writer) LogEmitter {
 	return LogEmitter{
-		Logger: scribe.NewLogger(output),
+		Emitter: scribe.NewEmitter(output),
 	}
-}
-
-func (e LogEmitter) SelectedDependency(entry packit.BuildpackPlanEntry, dependency postal.Dependency, now time.Time) {
-	source, ok := entry.Metadata["version-source"].(string)
-	if !ok {
-		source = "<unknown>"
-	}
-
-	e.Subprocess("Selected %s version (using %s): %s", dependency.Name, source, dependency.Version)
-
-	if (dependency.DeprecationDate != time.Time{}) {
-		deprecationDate := dependency.DeprecationDate
-		switch {
-		case (deprecationDate.Add(-30*24*time.Hour).Before(now) && deprecationDate.After(now)):
-			e.Action("Version %s of %s will be deprecated after %s.", dependency.Version, dependency.Name, dependency.DeprecationDate.Format("2006-01-02"))
-			e.Action("Migrate your application to a supported version of %s before this time.", dependency.Name)
-		case (deprecationDate == now || deprecationDate.Before(now)):
-			e.Action("Version %s of %s is deprecated.", dependency.Version, dependency.Name)
-			e.Action("Migrate your application to a supported version of %s.", dependency.Name)
-		}
-	}
-	e.Break()
 }
 
 func (e LogEmitter) Environment(env packit.Environment, optimizeMemory bool) {

--- a/log_emitter_test.go
+++ b/log_emitter_test.go
@@ -3,11 +3,9 @@ package nodeengine_test
 import (
 	"bytes"
 	"testing"
-	"time"
 
 	nodeengine "github.com/paketo-buildpacks/node-engine"
 	"github.com/paketo-buildpacks/packit"
-	"github.com/paketo-buildpacks/packit/postal"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"
@@ -24,99 +22,6 @@ func testLogEmitter(t *testing.T, context spec.G, it spec.S) {
 	it.Before(func() {
 		buffer = bytes.NewBuffer(nil)
 		emitter = nodeengine.NewLogEmitter(buffer)
-	})
-
-	context("SelectedDependency", func() {
-		it("prints details about the selected dependency", func() {
-			entry := packit.BuildpackPlanEntry{
-				Metadata: map[string]interface{}{"version-source": "some-source"},
-			}
-			dependency := postal.Dependency{
-				Name:    "Node Engine",
-				Version: "some-version",
-			}
-
-			emitter.SelectedDependency(entry, dependency, time.Now())
-			Expect(buffer.String()).To(Equal("    Selected Node Engine version (using some-source): some-version\n\n"))
-		})
-
-		context("when the version source is missing", func() {
-			it("prints details about the selected dependency", func() {
-				dependency := postal.Dependency{
-					Name:    "Node Engine",
-					Version: "some-version",
-				}
-
-				emitter.SelectedDependency(packit.BuildpackPlanEntry{}, dependency, time.Now())
-				Expect(buffer.String()).To(Equal("    Selected Node Engine version (using <unknown>): some-version\n\n"))
-			})
-		})
-
-		context("when it is within 30 days of the deprecation date", func() {
-			it("returns a warning that the dependency will be deprecated after the deprecation date", func() {
-				deprecationDate, err := time.Parse(time.RFC3339, "2021-04-01T00:00:00Z")
-				Expect(err).NotTo(HaveOccurred())
-				now := deprecationDate.Add(-29 * 24 * time.Hour)
-
-				entry := packit.BuildpackPlanEntry{
-					Metadata: map[string]interface{}{"version-source": "some-source"},
-				}
-				dependency := postal.Dependency{
-					DeprecationDate: deprecationDate,
-					Name:            "Node Engine",
-					Version:         "some-version",
-				}
-
-				emitter.SelectedDependency(entry, dependency, now)
-				Expect(buffer.String()).To(ContainSubstring("    Selected Node Engine version (using some-source): some-version\n"))
-				Expect(buffer.String()).To(ContainSubstring("      Version some-version of Node Engine will be deprecated after 2021-04-01.\n"))
-				Expect(buffer.String()).To(ContainSubstring("      Migrate your application to a supported version of Node Engine before this time.\n\n"))
-			})
-		})
-
-		context("when it is on the the deprecation date", func() {
-			it("returns a warning that the version of the dependency is no longer supported", func() {
-				deprecationDate, err := time.Parse(time.RFC3339, "2021-04-01T00:00:00Z")
-				Expect(err).NotTo(HaveOccurred())
-				now := deprecationDate
-
-				entry := packit.BuildpackPlanEntry{
-					Metadata: map[string]interface{}{"version-source": "some-source"},
-				}
-				dependency := postal.Dependency{
-					DeprecationDate: deprecationDate,
-					Name:            "Node Engine",
-					Version:         "some-version",
-				}
-
-				emitter.SelectedDependency(entry, dependency, now)
-				Expect(buffer.String()).To(ContainSubstring("    Selected Node Engine version (using some-source): some-version\n"))
-				Expect(buffer.String()).To(ContainSubstring("      Version some-version of Node Engine is deprecated.\n"))
-				Expect(buffer.String()).To(ContainSubstring("      Migrate your application to a supported version of Node Engine.\n\n"))
-			})
-		})
-
-		context("when it is after the the deprecation date", func() {
-			it("returns a warning that the version of the dependency is no longer supported", func() {
-				deprecationDate, err := time.Parse(time.RFC3339, "2021-04-01T00:00:00Z")
-				Expect(err).NotTo(HaveOccurred())
-				now := deprecationDate.Add(24 * time.Hour)
-
-				entry := packit.BuildpackPlanEntry{
-					Metadata: map[string]interface{}{"version-source": "some-source"},
-				}
-				dependency := postal.Dependency{
-					DeprecationDate: deprecationDate,
-					Name:            "Node Engine",
-					Version:         "some-version",
-				}
-
-				emitter.SelectedDependency(entry, dependency, now)
-				Expect(buffer.String()).To(ContainSubstring("    Selected Node Engine version (using some-source): some-version\n"))
-				Expect(buffer.String()).To(ContainSubstring("      Version some-version of Node Engine is deprecated.\n"))
-				Expect(buffer.String()).To(ContainSubstring("      Migrate your application to a supported version of Node Engine.\n\n"))
-			})
-		})
 	})
 
 	context("Environment", func() {


### PR DESCRIPTION
Thanks for contributing. To speed up the process of reviewing your pull request
please provide us with:

* A short explanation of the proposed change:

Use scribe.emitter generic logger for EOS logging.

Please confirm the following:
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have added an integration test, if necessary.
