### PR TITLE
User set env

### DIFF
--- a/environment.go
+++ b/environment.go
@@ -32,9 +32,18 @@ func NewEnvironment(logger LogEmitter) Environment {
 }
 
 func (e Environment) Configure(env packit.Environment, path string, optimizeMemory bool) error {
-	env.Override("NODE_HOME", path)
-	env.Override("NODE_ENV", "production")
-	env.Override("NODE_VERBOSE", "false")
+	env.Default("NODE_HOME", path)
+	if val, ok := os.LookupEnv("NODE_ENV"); ok {
+		env.Default("NODE_ENV", val)
+	} else {
+		env.Default("NODE_ENV", "production")
+	}
+
+	if val, ok := os.LookupEnv("NODE_VERBOSE"); ok {
+		env.Default("NODE_VERBOSE", val)
+	} else {
+		env.Default("NODE_VERBOSE", "false")
+	}
 
 	profileDPath := filepath.Join(path, "profile.d")
 	err := os.MkdirAll(profileDPath, os.ModePerm)

--- a/environment_test.go
+++ b/environment_test.go
@@ -59,10 +59,30 @@ func testEnvironment(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(env).To(Equal(packit.Environment{
-				"NODE_HOME.override":    path,
-				"NODE_ENV.override":     "production",
-				"NODE_VERBOSE.override": "false",
+				"NODE_HOME.default":    path,
+				"NODE_ENV.default":     "production",
+				"NODE_VERBOSE.default": "false",
 			}))
+		})
+
+		context("when NODE_ENV, NODE_VERBOSE are set", func() {
+			it.Before(func() {
+				os.Setenv("NODE_ENV", "some-node-env-val")
+				os.Setenv("NODE_VERBOSE", "some-node-verbose-val")
+			})
+
+			it.After(func() {
+				os.Unsetenv("NODE_ENV")
+				os.Unsetenv("NODE_VERBOSE")
+			})
+
+			it("configures variables using given value", func() {
+				err := environment.Configure(env, path, false)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(env["NODE_ENV.default"]).To(Equal("some-node-env-val"))
+				Expect(env["NODE_VERBOSE.default"]).To(Equal("some-node-verbose-val"))
+			})
 		})
 
 		it("writes a profile.d script for available memory", func() {

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -80,7 +80,7 @@ func TestIntegration(t *testing.T) {
 	SetDefaultEventuallyTimeout(5 * time.Second)
 
 	suite := spec.New("Integration", spec.Report(report.Terminal{}), spec.Parallel())
-	suite("Logging", testLogging)
+	suite("Simple", testSimple)
 	suite("Offline", testOffline)
 	suite("OptimizeMemory", testOptimizeMemory)
 	suite("Provides", testProvides)

--- a/log_emitter_test.go
+++ b/log_emitter_test.go
@@ -27,9 +27,9 @@ func testLogEmitter(t *testing.T, context spec.G, it spec.S) {
 	context("Environment", func() {
 		it("prints details about the environment", func() {
 			emitter.Environment(packit.Environment{
-				"NODE_HOME.override":    "/some/path",
-				"NODE_ENV.override":     "production",
-				"NODE_VERBOSE.override": "false",
+				"NODE_HOME.default":    "/some/path",
+				"NODE_ENV.default":     "production",
+				"NODE_VERBOSE.default": "false",
 			}, true)
 
 			Expect(buffer.String()).To(ContainSubstring("  Configuring environment"))
@@ -47,9 +47,9 @@ func testLogEmitter(t *testing.T, context spec.G, it spec.S) {
 		context("when not optimizing memory", func() {
 			it("omits those details", func() {
 				emitter.Environment(packit.Environment{
-					"NODE_HOME.override":    "/some/path",
-					"NODE_ENV.override":     "production",
-					"NODE_VERBOSE.override": "false",
+					"NODE_HOME.default":    "/some/path",
+					"NODE_ENV.default":     "production",
+					"NODE_VERBOSE.default": "false",
 				}, false)
 
 				Expect(buffer.String()).To(ContainSubstring("  Configuring environment"))


### PR DESCRIPTION
## Summary
* Changes env var setting behavior from [`override`](https://github.com/buildpacks/spec/blob/main/buildpack.md#override) rule to [`default`](https://github.com/buildpacks/spec/blob/main/buildpack.md#default) rule. This allows users to set variable values for `NODE_ENV` and `NODE_VERBOSE`.
* This value is now set as:
(1) default value in the build phase of subsequent buildpacks, and
(2) default value in the launch phase of the built container image, unless overridden by subsequent buildpacks

* In order to allow `devDependencies` to be installed, further changes is required on top of `npm-install` v0.2.5. It needs to respect user provided value for `NPM_CONFIG_PRODUCTION`

Resolves #196

## Use Cases
Allow users to build devDependenices by specifying value for NODE_ENV
Allow users to set NODE_VERBOSE

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have added an integration test, if necessary.
