### PR TITLE
Update nvmrc parser lts map

### DIFF
--- a/nvmrc_parser.go
+++ b/nvmrc_parser.go
@@ -15,6 +15,9 @@ var (
 		"boron":   6,
 		"carbon":  8,
 		"dubnium": 10,
+		"erbium":  12,
+		"fermium": 14,
+		"gallium": 16,
 	}
 )
 

--- a/nvmrc_parser_test.go
+++ b/nvmrc_parser_test.go
@@ -44,11 +44,14 @@ func testNvmrcParser(t *testing.T, context spec.G, it spec.S) {
 			"10.1.1":      "10.1.1",
 			"10.1.*":      "10.1.*",
 			"10.*":        "10.*",
-			"lts/*":       "10.*",
+			"lts/*":       "16.*",
 			"lts/argon":   "4.*",
 			"lts/boron":   "6.*",
 			"lts/carbon":  "8.*",
 			"lts/dubnium": "10.*",
+			"lts/erbium":  "12.*",
+			"lts/fermium": "14.*",
+			"lts/gallium": "16.*",
 			"node":        "*",
 		}
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Added missing recent LTS map for nvmrc parser.

## Use Cases
<!-- An explanation of the use cases your change enables -->
Fix buildpacks selecting `10.*` when someone specified `lts/*` in `.nvmrc`.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
