### PR TITLE
Use layer.ExecD to add optimize-memory executable to the layer

### DIFF
--- a/build.go
+++ b/build.go
@@ -9,7 +9,6 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/paketo-buildpacks/packit/v2"
 	"github.com/paketo-buildpacks/packit/v2/chronos"
-	"github.com/paketo-buildpacks/packit/v2/fs"
 	"github.com/paketo-buildpacks/packit/v2/postal"
 	"github.com/paketo-buildpacks/packit/v2/sbom"
 	"github.com/paketo-buildpacks/packit/v2/scribe"
@@ -165,16 +164,7 @@ func Build(entryResolver EntryResolver, dependencyManager DependencyManager, sbo
 
 		logger.EnvironmentVariables(nodeLayer)
 
-		execdDir := filepath.Join(nodeLayer.Path, "exec.d")
-		err = os.MkdirAll(execdDir, os.ModePerm)
-		if err != nil {
-			return packit.BuildResult{}, err
-		}
-
-		err = fs.Copy(filepath.Join(context.CNBPath, "bin", "optimize-memory"), filepath.Join(execdDir, "0-optimize-memory"))
-		if err != nil {
-			return packit.BuildResult{}, err
-		}
+		nodeLayer.ExecD = []string{filepath.Join(context.CNBPath, "bin", "optimize-memory")}
 
 		logger.Subprocess("Writing exec.d/0-optimize-memory")
 		logger.Action("Calculates available memory based on container limits at launch time.")

--- a/build_test.go
+++ b/build_test.go
@@ -133,6 +133,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			"NODE_ENV.default":     "production",
 			"NODE_VERBOSE.default": "false",
 		}))
+		Expect(layer.ExecD).To(Equal([]string{
+			filepath.Join(cnbDir, "bin", "optimize-memory"),
+		}))
 
 		Expect(layer.Metadata).To(Equal(map[string]interface{}{
 			nodeengine.DepKey: "",
@@ -500,17 +503,6 @@ nodejs:
 			it("returns an error", func() {
 				_, err := build(buildContext)
 				Expect(err).To(MatchError(ContainSubstring("permission denied")))
-			})
-		})
-
-		context("when copying the file fails", func() {
-			it.Before(func() {
-				Expect(os.RemoveAll(filepath.Join(cnbDir, "bin"))).To(Succeed())
-			})
-
-			it("returns an error", func() {
-				_, err := build(buildContext)
-				Expect(err).To(MatchError(ContainSubstring("no such file or directory")))
 			})
 		})
 	})

--- a/build_test.go
+++ b/build_test.go
@@ -49,9 +49,6 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		workingDir, err = os.MkdirTemp("", "working-dir")
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(os.MkdirAll(filepath.Join(cnbDir, "bin"), os.ModePerm)).To(Succeed())
-		Expect(os.WriteFile(filepath.Join(cnbDir, "bin", "optimize-memory"), nil, os.ModePerm)).To(Succeed())
-
 		entryResolver = &fakes.EntryResolver{}
 		entryResolver.ResolveCall.Returns.BuildpackPlanEntry = packit.BuildpackPlanEntry{
 			Name: "node",


### PR DESCRIPTION
## Summary
Use layer.ExecD to add optimize-memory executable to the layer, using [packit 2.2.0](https://github.com/paketo-buildpacks/packit/releases/tag/v2.2.0).

## Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
