### PR TITLE
Set `SSL_CERT_DIR`  for Node v18 and higher

### DIFF
--- a/build.go
+++ b/build.go
@@ -176,6 +176,17 @@ func Build(entryResolver EntryResolver, dependencyManager DependencyManager, sbo
 			nodeLayer.LaunchEnv.Default("OPTIMIZE_MEMORY", "true")
 		}
 
+		// NOTE: ensures OpenSSL CA store works with Node v18 and higher. Waiting
+		// for resolution on https://github.com/nodejs/node/issues/43560 to decide
+		// how to properly fix this.
+		nodeVersion, err := semver.NewVersion(dependency.Version)
+		if err != nil {
+			return packit.BuildResult{}, err
+		}
+		if !nodeVersion.LessThan(semver.MustParse("18.0.0")) {
+			nodeLayer.SharedEnv.Append("SSL_CERT_DIR", "/etc/ssl/certs", ":")
+		}
+
 		logger.EnvironmentVariables(nodeLayer)
 
 		nodeLayer.ExecD = []string{filepath.Join(context.CNBPath, "bin", "optimize-memory")}

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -137,12 +137,13 @@ func TestIntegration(t *testing.T) {
 	SetDefaultEventuallyTimeout(5 * time.Second)
 
 	suite := spec.New("Integration", spec.Report(report.Terminal{}), spec.Parallel())
-	suite("Simple", testSimple)
 	suite("Buildpack.yml", testBuildpackYML)
 	suite("Offline", testOffline)
 	suite("OptimizeMemory", testOptimizeMemory)
 	suite("ProjectPath", testProjectPath)
 	suite("Provides", testProvides)
 	suite("ReusingLayerRebuild", testReusingLayerRebuild)
+	suite("Simple", testSimple)
+	suite("OpenSSL", testOpenSSL)
 	suite.Run(t)
 }

--- a/integration/openssl_test.go
+++ b/integration/openssl_test.go
@@ -1,0 +1,142 @@
+package integration
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/paketo-buildpacks/occam"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+	. "github.com/paketo-buildpacks/occam/matchers"
+)
+
+func testOpenSSL(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect     = NewWithT(t).Expect
+		Eventually = NewWithT(t).Eventually
+
+		pack   occam.Pack
+		docker occam.Docker
+	)
+
+	it.Before(func() {
+		pack = occam.NewPack()
+		docker = occam.NewDocker()
+	})
+
+	context("when the buildpack is run with pack build", func() {
+		var (
+			image     occam.Image
+			container occam.Container
+			name      string
+			source    string
+			sbomDir   string
+		)
+
+		it.Before(func() {
+			var err error
+			name, err = occam.RandomName()
+			Expect(err).NotTo(HaveOccurred())
+
+			sbomDir, err = os.MkdirTemp("", "sbom")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(os.Chmod(sbomDir, os.ModePerm)).To(Succeed())
+
+			source, err = occam.Source(filepath.Join("testdata", "simple_app"))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		it.After(func() {
+			Expect(docker.Container.Remove.Execute(container.ID)).To(Succeed())
+			Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
+			Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
+			Expect(os.RemoveAll(source)).To(Succeed())
+			Expect(os.RemoveAll(sbomDir)).To(Succeed())
+		})
+
+		context("when running Node 16", func() {
+			it("uses the OpenSSL CA store to verify certificates", func() {
+				var (
+					logs fmt.Stringer
+					err  error
+				)
+
+				image, logs, err = pack.WithNoColor().Build.
+					WithBuildpacks(
+						settings.Buildpacks.NodeEngine.Online,
+						settings.Buildpacks.BuildPlan.Online,
+					).
+					WithPullPolicy("never").
+					WithEnv(map[string]string{
+						"BP_NODE_VERSION": "16.*.*",
+					}).
+					Execute(name, source)
+				Expect(err).ToNot(HaveOccurred(), logs.String)
+
+				container, err = docker.Container.Run.
+					WithPublish("8080").
+					WithCommand("node server.js").
+					Execute(image.ID)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(container).Should(Serve("hello world"))
+				Expect(container).To(Serve(ContainSubstring("v16.")).WithEndpoint("/version"))
+				Expect(container).To(Serve(ContainSubstring("301 Moved")).WithEndpoint("/test-openssl-ca"))
+
+				Expect(logs).To(ContainLines(
+					"  Configuring launch environment",
+					`    NODE_ENV     -> "production"`,
+					fmt.Sprintf(`    NODE_HOME    -> "/layers/%s/node"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
+					`    NODE_VERBOSE -> "false"`,
+				))
+
+				Expect(logs).NotTo(ContainLines(
+					`    SSL_CERT_DIR -> "$SSL_CERT_DIR:/etc/ssl/certs"`,
+				))
+			})
+		})
+
+		context("when running Node 18", func() {
+			it("uses the OpenSSL CA store to verify certificates", func() {
+				var (
+					logs fmt.Stringer
+					err  error
+				)
+
+				image, logs, err = pack.WithNoColor().Build.
+					WithBuildpacks(
+						settings.Buildpacks.NodeEngine.Online,
+						settings.Buildpacks.BuildPlan.Online,
+					).
+					WithPullPolicy("never").
+					WithEnv(map[string]string{
+						"BP_NODE_VERSION": "18.*.*",
+					}).
+					Execute(name, source)
+				Expect(err).ToNot(HaveOccurred(), logs.String)
+
+				container, err = docker.Container.Run.
+					WithPublish("8080").
+					WithCommand("node server.js").
+					Execute(image.ID)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(container).Should(Serve("hello world"))
+				Expect(container).To(Serve(ContainSubstring("v18.")).WithEndpoint("/version"))
+				Expect(container).To(Serve(ContainSubstring("301 Moved")).WithEndpoint("/test-openssl-ca"))
+
+				Expect(logs).To(ContainLines(
+					"  Configuring launch environment",
+					`    NODE_ENV     -> "production"`,
+					fmt.Sprintf(`    NODE_HOME    -> "/layers/%s/node"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
+					`    NODE_VERBOSE -> "false"`,
+					`    SSL_CERT_DIR -> "$SSL_CERT_DIR:/etc/ssl/certs"`,
+				))
+			})
+		})
+	})
+}

--- a/integration/testdata/simple_app/server.js
+++ b/integration/testdata/simple_app/server.js
@@ -1,16 +1,33 @@
-const http = require('http')
-const port = process.env.PORT || 8080
+const http = require('http');
+const https = require('https');
+const port = process.env.PORT || 8080;
 
-const requestHandler = (request, response) => {
-    response.end("hello world")
-}
+const server = http.createServer((request, response) => {
+  switch (request.url) {
+    case '/test-openssl-ca':
+      https.get('https://google.com', (res) => {
+        res.setEncoding('utf8');
+        let data = '';
+        res.on('data', (chunk) => { data += chunk; });
+        res.on('end', () => { response.end(data); });
+      }).on('error', (e) => {
+        response.end(e.toString());
+      });
+      break;
 
-const server = http.createServer(requestHandler)
+    case '/version':
+      response.end(process.version);
+      break;
+
+    default:
+      response.end("hello world");
+  }
+});
 
 server.listen(port, (err) => {
     if (err) {
-        return console.log('something bad happened', err)
+        return console.log('something bad happened', err);
     }
 
-    console.log(`server is listening on ${port}`)
-})
+    console.log(`server is listening on ${port}`);
+});


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Node v18 has upgraded its OpenSSL implementation to v3. This broke our expectations for how CA certificate verification works. We will need to explicitly tell the OpenSSL implementation where the default CA store lives on the filesystem.

I've opened this issue on the Node repo to find out what the expected behavior is: https://github.com/nodejs/node/issues/43560

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
