### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.7"
 [buildpack]
   homepage = "https://github.com/paketo-buildpacks/node-engine"
   id = "paketo-buildpacks/node-engine"
-  name = "Paketo Node Engine Buildpack"
+  name = "Paketo Buildpack for Node Engine"
   sbom-formats = ["application/vnd.cyclonedx+json", "application/spdx+json", "application/vnd.syft+json"]
 
   [[buildpack.licenses]]


### PR DESCRIPTION
Renames 'Paketo Node Engine Buildpack' to 'Paketo Buildpack for Node Engine'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
