### PR TITLE
allow node-engine to run on any stack

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -229,3 +229,6 @@ api = "0.7"
 
 [[stacks]]
   id = "io.buildpacks.stacks.jammy"
+
+[[stacks]]
+  id = "*"


### PR DESCRIPTION
We are working to support the paketo buildpacks
with ubi8. Allow node-engine to run on any stack
in order to allow this.

Signed-off-by: Michael Dawson <mdawson@devrus.com>

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
We are working to support the paketo buildpacks
with ubi8. Allow node-engine to run on any stack
in order to allow this.

## Use Cases
<!-- An explanation of the use cases your change enables -->
Allows Paketo build packs to be used with other stack like ubi8

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
