### PR TITLE
Store build,launch in cached metadata to verify if layer can be reused

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -5,6 +5,8 @@ const (
 	Npm  = "npm"
 
 	DepKey             = "dependency-sha"
+	BuildKey           = "build"
+	LaunchKey          = "launch"
 	NvmrcSource        = ".nvmrc"
 	BuildpackYMLSource = "buildpack.yml"
 	NodeVersionSource  = ".node-version"

--- a/init_test.go
+++ b/init_test.go
@@ -10,6 +10,7 @@ import (
 func TestUnitNode(t *testing.T) {
 	suite := spec.New("node", spec.Report(report.Terminal{}))
 	suite("Build", testBuild)
+	suite("IsLayerReusable", testIsLayerReusable)
 	suite("Detect", testDetect)
 	suite("NvmrcParser", testNvmrcParser)
 	suite("NodeVersionParser", testNodeVersionParser)


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->
Fixes #394 

## Summary
<!-- A short explanation of the proposed change -->
The information if the `node` dependency is installed to build and/or launch layer is added to the metadata of the layer. So when reusing a layer from the cache, we can verify that this information is unchanged. And only then reuse the layer.

## Use Cases
<!-- An explanation of the use cases your change enables -->
Bugfix: If the cached layer didn't need node during build, but the current call would, the layer would still be reused which caused `npm` not being available at build time.


## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
