### PR TITLE
Improve resiliency of integration tests.

### DIFF
--- a/integration/optimize_memory_test.go
+++ b/integration/optimize_memory_test.go
@@ -78,7 +78,8 @@ func testOptimizeMemory(t *testing.T, context spec.G, it spec.S) {
 			`    NODE_OPTIONS    -> "--use-openssl-ca"`,
 			`    NODE_VERBOSE    -> "false"`,
 			`    OPTIMIZE_MEMORY -> "true"`,
-			"",
+		))
+		Expect(logs).To(ContainLines(
 			"    Writing exec.d/0-optimize-memory",
 			"      Calculates available memory based on container limits at launch time.",
 			"      Made available in the MEMORY_AVAILABLE environment variable.",

--- a/integration/project_path_test.go
+++ b/integration/project_path_test.go
@@ -75,7 +75,8 @@ func testProjectPath(t *testing.T, context spec.G, it spec.S) {
 				"    Candidate version sources (in priority order):",
 				"      .node-version -> \"16.*\"",
 				"      <unknown>     -> \"\"",
-				"",
+			))
+			Expect(logs).To(ContainLines(
 				MatchRegexp(`    Selected Node Engine version \(using \.node-version\): 16\.\d+\.\d+`),
 			))
 

--- a/integration/provides_test.go
+++ b/integration/provides_test.go
@@ -66,28 +66,34 @@ func testProvides(t *testing.T, context spec.G, it spec.S) {
 				"  Resolving Node Engine version",
 				"    Candidate version sources (in priority order):",
 				"      <unknown> -> \"\"",
-				"",
+			))
+			Expect(logs).To(ContainLines(
 				MatchRegexp(`    Selected Node Engine version \(using <unknown>\): 18\.\d+\.\d+`),
-				"",
+			))
+			Expect(logs).To(ContainLines(
 				"  Executing build process",
 				MatchRegexp(`    Installing Node Engine 18\.\d+\.\d+`),
 				MatchRegexp(`      Completed in \d+(\.\d+)?`),
-				"",
+			))
+			Expect(logs).To(ContainLines(
 				fmt.Sprintf("  Generating SBOM for /layers/%s/node", strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
 				MatchRegexp(`      Completed in \d+(\.?\d+)*`),
-				"",
+			))
+			Expect(logs).To(ContainLines(
 				"  Configuring build environment",
 				`    NODE_ENV     -> "production"`,
 				fmt.Sprintf(`    NODE_HOME    -> "/layers/%s/node"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
 				`    NODE_OPTIONS -> "--use-openssl-ca"`,
 				`    NODE_VERBOSE -> "false"`,
-				"",
+			))
+			Expect(logs).To(ContainLines(
 				"  Configuring launch environment",
 				`    NODE_ENV     -> "production"`,
 				fmt.Sprintf(`    NODE_HOME    -> "/layers/%s/node"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
 				`    NODE_OPTIONS -> "--use-openssl-ca"`,
 				`    NODE_VERBOSE -> "false"`,
-				"",
+			))
+			Expect(logs).To(ContainLines(
 				"    Writing exec.d/0-optimize-memory",
 				"      Calculates available memory based on container limits at launch time.",
 				"      Made available in the MEMORY_AVAILABLE environment variable.",

--- a/integration/reuse_layer_rebuild_test.go
+++ b/integration/reuse_layer_rebuild_test.go
@@ -89,28 +89,34 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 				"  Resolving Node Engine version",
 				"    Candidate version sources (in priority order):",
 				"      <unknown> -> \"\"",
-				"",
+			))
+			Expect(logs).To(ContainLines(
 				MatchRegexp(`    Selected Node Engine version \(using <unknown>\): \d+\.\d+\.\d+`),
-				"",
+			))
+			Expect(logs).To(ContainLines(
 				"  Executing build process",
 				MatchRegexp(`    Installing Node Engine \d+\.\d+\.\d+`),
 				MatchRegexp(`      Completed in \d+(\.\d+)?`),
-				"",
+			))
+			Expect(logs).To(ContainLines(
 				fmt.Sprintf("  Generating SBOM for /layers/%s/node", strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
 				MatchRegexp(`      Completed in \d+(\.?\d+)*`),
-				"",
+			))
+			Expect(logs).To(ContainLines(
 				"  Configuring build environment",
 				`    NODE_ENV     -> "production"`,
 				fmt.Sprintf(`    NODE_HOME    -> "/layers/%s/node"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
 				`    NODE_OPTIONS -> "--use-openssl-ca"`,
 				`    NODE_VERBOSE -> "false"`,
-				"",
+			))
+			Expect(logs).To(ContainLines(
 				"  Configuring launch environment",
 				`    NODE_ENV     -> "production"`,
 				fmt.Sprintf(`    NODE_HOME    -> "/layers/%s/node"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
 				`    NODE_OPTIONS -> "--use-openssl-ca"`,
 				`    NODE_VERBOSE -> "false"`,
-				"",
+			))
+			Expect(logs).To(ContainLines(
 				"    Writing exec.d/0-optimize-memory",
 				"      Calculates available memory based on container limits at launch time.",
 				"      Made available in the MEMORY_AVAILABLE environment variable.",
@@ -148,9 +154,11 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 				"  Resolving Node Engine version",
 				"    Candidate version sources (in priority order):",
 				"      <unknown> -> \"\"",
-				"",
+			))
+			Expect(logs).To(ContainLines(
 				MatchRegexp(`    Selected Node Engine version \(using <unknown>\): \d+\.\d+\.\d+`),
-				"",
+			))
+			Expect(logs).To(ContainLines(
 				fmt.Sprintf("  Reusing cached layer /layers/%s/node", strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
 			))
 
@@ -214,28 +222,34 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 				"    Candidate version sources (in priority order):",
 				"      BP_NODE_VERSION -> \"~16\"",
 				"      <unknown>       -> \"\"",
-				"",
+			))
+			Expect(logs).To(ContainLines(
 				MatchRegexp(`    Selected Node Engine version \(using BP_NODE_VERSION\): 16\.\d+\.\d+`),
-				"",
+			))
+			Expect(logs).To(ContainLines(
 				"  Executing build process",
 				MatchRegexp(`    Installing Node Engine 16\.\d+\.\d+`),
 				MatchRegexp(`      Completed in \d+(\.\d+)?`),
-				"",
+			))
+			Expect(logs).To(ContainLines(
 				fmt.Sprintf("  Generating SBOM for /layers/%s/node", strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
 				MatchRegexp(`      Completed in \d+(\.?\d+)*`),
-				"",
+			))
+			Expect(logs).To(ContainLines(
 				"  Configuring build environment",
 				`    NODE_ENV     -> "production"`,
 				fmt.Sprintf(`    NODE_HOME    -> "/layers/%s/node"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
 				`    NODE_OPTIONS -> "--use-openssl-ca"`,
 				`    NODE_VERBOSE -> "false"`,
-				"",
+			))
+			Expect(logs).To(ContainLines(
 				"  Configuring launch environment",
 				`    NODE_ENV     -> "production"`,
 				fmt.Sprintf(`    NODE_HOME    -> "/layers/%s/node"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
 				`    NODE_OPTIONS -> "--use-openssl-ca"`,
 				`    NODE_VERBOSE -> "false"`,
-				"",
+			))
+			Expect(logs).To(ContainLines(
 				"    Writing exec.d/0-optimize-memory",
 				"      Calculates available memory based on container limits at launch time.",
 				"      Made available in the MEMORY_AVAILABLE environment variable.",
@@ -275,28 +289,34 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 				"    Candidate version sources (in priority order):",
 				"      BP_NODE_VERSION -> \"~14\"",
 				"      <unknown>       -> \"\"",
-				"",
+			))
+			Expect(logs).To(ContainLines(
 				MatchRegexp(`    Selected Node Engine version \(using BP_NODE_VERSION\): 14\.\d+\.\d+`),
-				"",
+			))
+			Expect(logs).To(ContainLines(
 				"  Executing build process",
 				MatchRegexp(`    Installing Node Engine 14\.\d+\.\d+`),
 				MatchRegexp(`      Completed in \d+(\.\d+)?`),
-				"",
+			))
+			Expect(logs).To(ContainLines(
 				fmt.Sprintf("  Generating SBOM for /layers/%s/node", strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
 				MatchRegexp(`      Completed in \d+(\.?\d+)*`),
-				"",
+			))
+			Expect(logs).To(ContainLines(
 				"  Configuring build environment",
 				`    NODE_ENV     -> "production"`,
 				fmt.Sprintf(`    NODE_HOME    -> "/layers/%s/node"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
 				`    NODE_OPTIONS -> "--use-openssl-ca"`,
 				`    NODE_VERBOSE -> "false"`,
-				"",
+			))
+			Expect(logs).To(ContainLines(
 				"  Configuring launch environment",
 				`    NODE_ENV     -> "production"`,
 				fmt.Sprintf(`    NODE_HOME    -> "/layers/%s/node"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
 				`    NODE_OPTIONS -> "--use-openssl-ca"`,
 				`    NODE_VERBOSE -> "false"`,
-				"",
+			))
+			Expect(logs).To(ContainLines(
 				"    Writing exec.d/0-optimize-memory",
 				"      Calculates available memory based on container limits at launch time.",
 				"      Made available in the MEMORY_AVAILABLE environment variable.",

--- a/integration/simple_app_test.go
+++ b/integration/simple_app_test.go
@@ -86,33 +86,40 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 					"  Resolving Node Engine version",
 					"    Candidate version sources (in priority order):",
 					"      <unknown> -> \"\"",
-					"",
+				))
+				Expect(logs).To(ContainLines(
 					MatchRegexp(`    Selected Node Engine version \(using <unknown>\): \d+\.\d+\.\d+`),
-					"",
+				))
+				Expect(logs).To(ContainLines(
 					"  Executing build process",
 					MatchRegexp(`    Installing Node Engine \d+\.\d+\.\d+`),
 					MatchRegexp(`      Completed in \d+(\.\d+)?`),
-					"",
+				))
+				Expect(logs).To(ContainLines(
 					fmt.Sprintf("  Generating SBOM for /layers/%s/node", strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
 					MatchRegexp(`      Completed in \d+(\.?\d+)*`),
-					"",
+				))
+				Expect(logs).To(ContainLines(
 					"  Writing SBOM in the following format(s):",
 					"    application/vnd.cyclonedx+json",
 					"    application/spdx+json",
 					"    application/vnd.syft+json",
-					"",
+				))
+				Expect(logs).To(ContainLines(
 					"  Configuring build environment",
 					`    NODE_ENV     -> "production"`,
 					fmt.Sprintf(`    NODE_HOME    -> "/layers/%s/node"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
 					`    NODE_OPTIONS -> "--use-openssl-ca"`,
 					`    NODE_VERBOSE -> "false"`,
-					"",
+				))
+				Expect(logs).To(ContainLines(
 					"  Configuring launch environment",
 					`    NODE_ENV     -> "production"`,
 					fmt.Sprintf(`    NODE_HOME    -> "/layers/%s/node"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
 					`    NODE_OPTIONS -> "--use-openssl-ca"`,
 					`    NODE_VERBOSE -> "false"`,
-					"",
+				))
+				Expect(logs).To(ContainLines(
 					"    Writing exec.d/0-optimize-memory",
 					"      Calculates available memory based on container limits at launch time.",
 					"      Made available in the MEMORY_AVAILABLE environment variable.",
@@ -188,7 +195,8 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 					fmt.Sprintf(`    NODE_HOME    -> "/layers/%s/node"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
 					`    NODE_OPTIONS -> "--use-openssl-ca"`,
 					`    NODE_VERBOSE -> "false"`,
-					"",
+				))
+				Expect(logs).To(ContainLines(
 					"  Configuring launch environment",
 					`    NODE_ENV     -> "production"`,
 					fmt.Sprintf(`    NODE_HOME    -> "/layers/%s/node"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
@@ -252,28 +260,34 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 					"    Candidate version sources (in priority order):",
 					"      .node-version -> \"16.*\"",
 					"      <unknown>     -> \"\"",
-					"",
+				))
+				Expect(logs).To(ContainLines(
 					MatchRegexp(`    Selected Node Engine version \(using \.node-version\): 16\.\d+\.\d+`),
-					"",
+				))
+				Expect(logs).To(ContainLines(
 					"  Executing build process",
 					MatchRegexp(`    Installing Node Engine 16\.\d+\.\d+`),
 					MatchRegexp(`      Completed in \d+(\.\d+)?`),
-					"",
+				))
+				Expect(logs).To(ContainLines(
 					fmt.Sprintf("  Generating SBOM for /layers/%s/node", strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
 					MatchRegexp(`      Completed in \d+(\.?\d+)*`),
-					"",
+				))
+				Expect(logs).To(ContainLines(
 					"  Configuring build environment",
 					`    NODE_ENV     -> "production"`,
 					fmt.Sprintf(`    NODE_HOME    -> "/layers/%s/node"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
 					`    NODE_OPTIONS -> "--use-openssl-ca"`,
 					`    NODE_VERBOSE -> "false"`,
-					"",
+				))
+				Expect(logs).To(ContainLines(
 					"  Configuring launch environment",
 					`    NODE_ENV     -> "production"`,
 					fmt.Sprintf(`    NODE_HOME    -> "/layers/%s/node"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
 					`    NODE_OPTIONS -> "--use-openssl-ca"`,
 					`    NODE_VERBOSE -> "false"`,
-					"",
+				))
+				Expect(logs).To(ContainLines(
 					"    Writing exec.d/0-optimize-memory",
 					"      Calculates available memory based on container limits at launch time.",
 					"      Made available in the MEMORY_AVAILABLE environment variable.",
@@ -332,28 +346,34 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 					"    Candidate version sources (in priority order):",
 					"      .nvmrc    -> \"16.*\"",
 					"      <unknown> -> \"\"",
-					"",
+				))
+				Expect(logs).To(ContainLines(
 					MatchRegexp(`    Selected Node Engine version \(using \.nvmrc\): 16\.\d+\.\d+`),
-					"",
+				))
+				Expect(logs).To(ContainLines(
 					"  Executing build process",
 					MatchRegexp(`    Installing Node Engine 16\.\d+\.\d+`),
 					MatchRegexp(`      Completed in \d+(\.\d+)?`),
-					"",
+				))
+				Expect(logs).To(ContainLines(
 					fmt.Sprintf("  Generating SBOM for /layers/%s/node", strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
 					MatchRegexp(`      Completed in \d+(\.?\d+)*`),
-					"",
+				))
+				Expect(logs).To(ContainLines(
 					"  Configuring build environment",
 					`    NODE_ENV     -> "production"`,
 					fmt.Sprintf(`    NODE_HOME    -> "/layers/%s/node"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
 					`    NODE_OPTIONS -> "--use-openssl-ca"`,
 					`    NODE_VERBOSE -> "false"`,
-					"",
+				))
+				Expect(logs).To(ContainLines(
 					"  Configuring launch environment",
 					`    NODE_ENV     -> "production"`,
 					fmt.Sprintf(`    NODE_HOME    -> "/layers/%s/node"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
 					`    NODE_OPTIONS -> "--use-openssl-ca"`,
 					`    NODE_VERBOSE -> "false"`,
-					"",
+				))
+				Expect(logs).To(ContainLines(
 					"    Writing exec.d/0-optimize-memory",
 					"      Calculates available memory based on container limits at launch time.",
 					"      Made available in the MEMORY_AVAILABLE environment variable.",


### PR DESCRIPTION
## Summary

This PR improves the resiliency of the integration tests. Specifically, sometimes extra log lines appear outside of our control (e.g. nodejs deprecation warnings). Our tests should not fail because of them.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
