### PR TITLE
Removes jammy node v20 deps to force bionic compilation

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -219,36 +219,6 @@ api = "0.7"
     uri = "https://nodejs.org/dist/v19.9.0/node-v19.9.0-linux-x64.tar.xz"
     version = "19.9.0"
 
-  [[metadata.dependencies]]
-    checksum = "sha256:c12ee9efe21f3ff9909fbf5d7d3780f16c86fad411f13d715016646c766e8213"
-    cpe = "cpe:2.3:a:nodejs:node.js:20.5.0:*:*:*:*:*:*:*"
-    deprecation_date = "2026-04-30T00:00:00Z"
-    id = "node"
-    licenses = ["0BSD", "Apache-2.0", "Artistic-2.0", "BSD-2-Clause", "BSD-3-Clause", "BSD-4-Clause", "BSD-Source-Code", "CC0-1.0", "ECL-2.0", "ICU", "MIT", "MIT-0", "SHL-0.5", "SHL-0.51", "Unicode-TOU"]
-    name = "Node Engine"
-    purl = "pkg:generic/node@v20.5.0?checksum=c12ee9efe21f3ff9909fbf5d7d3780f16c86fad411f13d715016646c766e8213&download_url=https://nodejs.org/dist/v20.5.0/node-v20.5.0-linux-x64.tar.xz"
-    source = "https://nodejs.org/dist/v20.5.0/node-v20.5.0-linux-x64.tar.xz"
-    source-checksum = "sha256:c12ee9efe21f3ff9909fbf5d7d3780f16c86fad411f13d715016646c766e8213"
-    stacks = ["io.buildpacks.stacks.jammy"]
-    strip-components = 1
-    uri = "https://nodejs.org/dist/v20.5.0/node-v20.5.0-linux-x64.tar.xz"
-    version = "20.5.0"
-
-  [[metadata.dependencies]]
-    checksum = "sha256:a4a700bbca51ac26538eda2250e449955a9cc49638a45b38d5501e97f5b020b4"
-    cpe = "cpe:2.3:a:nodejs:node.js:20.5.1:*:*:*:*:*:*:*"
-    deprecation_date = "2026-04-30T00:00:00Z"
-    id = "node"
-    licenses = ["0BSD", "Apache-2.0", "Artistic-2.0", "BSD-2-Clause", "BSD-3-Clause", "BSD-4-Clause", "BSD-Source-Code", "CC0-1.0", "ECL-2.0", "ICU", "MIT", "MIT-0", "SHL-0.5", "SHL-0.51", "Unicode-TOU"]
-    name = "Node Engine"
-    purl = "pkg:generic/node@v20.5.1?checksum=a4a700bbca51ac26538eda2250e449955a9cc49638a45b38d5501e97f5b020b4&download_url=https://nodejs.org/dist/v20.5.1/node-v20.5.1-linux-x64.tar.xz"
-    source = "https://nodejs.org/dist/v20.5.1/node-v20.5.1-linux-x64.tar.xz"
-    source-checksum = "sha256:a4a700bbca51ac26538eda2250e449955a9cc49638a45b38d5501e97f5b020b4"
-    stacks = ["io.buildpacks.stacks.jammy"]
-    strip-components = 1
-    uri = "https://nodejs.org/dist/v20.5.1/node-v20.5.1-linux-x64.tar.xz"
-    version = "20.5.1"
-
   [[metadata.dependency-constraints]]
     constraint = "16.*"
     id = "node"


### PR DESCRIPTION
#683 added only the jammy v20 deps in the hope that the automation would eventually fill in the bionic dependencies. Removing those deps to force the retrieval and compilation of all v20 deps since the aforementioned approach did not work as intended.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
