### PR TITLE
Adding ubi-buildpackless-base builder on integration tests

### DIFF
--- a/integration.json
+++ b/integration.json
@@ -1,6 +1,8 @@
 {
   "build-plan": "github.com/paketo-community/build-plan",
+  "ubi-nodejs-extension": "github.com/paketo-community/ubi-nodejs-extension",
   "builders": [
+    "paketocommunity/builder-ubi-buildpackless-base:latest",
     "index.docker.io/paketobuildpacks/builder:buildpackless-base",
     "index.docker.io/paketobuildpacks/builder-jammy-buildpackless-base:latest"
   ]

--- a/integration/offline_test.go
+++ b/integration/offline_test.go
@@ -40,10 +40,6 @@ func testOffline(t *testing.T, context spec.G, it spec.S) {
 			var err error
 			name, err = occam.RandomName()
 			Expect(err).NotTo(HaveOccurred())
-
-			if settings.Extensions.UbiNodejsExtension.Online != "" {
-				pullPolicy = "always"
-			}
 		})
 
 		it.After(func() {
@@ -54,6 +50,12 @@ func testOffline(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		it("sets max_old_space_size when nodejs.optimize-memory is set with env variable BP_NODE_OPTIMIZE_MEMORY", func() {
+
+			//UBI does not support offline build ATM
+			if settings.Extensions.UbiNodejsExtension.Online != "" {
+				return
+			}
+
 			var err error
 			source, err = occam.Source(filepath.Join("testdata", "optimize_memory"))
 			Expect(err).NotTo(HaveOccurred())

--- a/integration/openssl_test.go
+++ b/integration/openssl_test.go
@@ -158,11 +158,14 @@ func testOpenSSL(t *testing.T, context spec.G, it spec.S) {
 				)
 
 				image, logs, err = pack.WithNoColor().Build.
+					WithExtensions(
+						settings.Extensions.UbiNodejsExtension.Online,
+					).
 					WithBuildpacks(
 						settings.Buildpacks.NodeEngine.Online,
 						settings.Buildpacks.BuildPlan.Online,
 					).
-					WithPullPolicy("never").
+					WithPullPolicy(pullPolicy).
 					WithEnv(map[string]string{
 						"BP_NODE_VERSION": "20.*.*",
 					}).
@@ -180,11 +183,11 @@ func testOpenSSL(t *testing.T, context spec.G, it spec.S) {
 				Expect(container).To(Serve(ContainSubstring("301 Moved")).WithEndpoint("/test-openssl-ca"))
 
 				Expect(logs).To(ContainLines(
-					"  Configuring launch environment",
-					`    NODE_ENV     -> "production"`,
-					fmt.Sprintf(`    NODE_HOME    -> "/layers/%s/node"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
-					`    NODE_OPTIONS -> "--use-openssl-ca"`,
-					`    NODE_VERBOSE -> "false"`,
+					extenderBuildStr+"  Configuring launch environment",
+					extenderBuildStr+`    NODE_ENV     -> "production"`,
+					fmt.Sprintf(`%s    NODE_HOME    -> "/layers/%s/node"`, extenderBuildStr, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
+					extenderBuildStr+`    NODE_OPTIONS -> "--use-openssl-ca"`,
+					extenderBuildStr+`    NODE_VERBOSE -> "false"`,
 				))
 			})
 		})

--- a/integration/openssl_test.go
+++ b/integration/openssl_test.go
@@ -65,7 +65,7 @@ func testOpenSSL(t *testing.T, context spec.G, it spec.S) {
 			Expect(os.RemoveAll(sbomDir)).To(Succeed())
 		})
 
-		context("when running Node 16", func() {
+		context("when running Node 18", func() {
 			it("uses the OpenSSL CA store to verify certificates", func() {
 				var (
 					logs fmt.Stringer
@@ -82,7 +82,7 @@ func testOpenSSL(t *testing.T, context spec.G, it spec.S) {
 					).
 					WithPullPolicy(pullPolicy).
 					WithEnv(map[string]string{
-						"BP_NODE_VERSION": "16.*.*",
+						"BP_NODE_VERSION": "18.*.*",
 					}).
 					Execute(name, source)
 				Expect(err).ToNot(HaveOccurred(), logs.String)
@@ -94,7 +94,7 @@ func testOpenSSL(t *testing.T, context spec.G, it spec.S) {
 				Expect(err).NotTo(HaveOccurred())
 
 				Eventually(container).Should(Serve("hello world"))
-				Expect(container).To(Serve(ContainSubstring("v16.")).WithEndpoint("/version"))
+				Expect(container).To(Serve(ContainSubstring("v18.")).WithEndpoint("/version"))
 				Expect(container).To(Serve(ContainSubstring("301 Moved")).WithEndpoint("/test-openssl-ca"))
 
 				Expect(logs).To(ContainLines(

--- a/integration/openssl_test.go
+++ b/integration/openssl_test.go
@@ -35,6 +35,9 @@ func testOpenSSL(t *testing.T, context spec.G, it spec.S) {
 			name      string
 			source    string
 			sbomDir   string
+
+			pullPolicy       = "never"
+			extenderBuildStr = ""
 		)
 
 		it.Before(func() {
@@ -48,6 +51,10 @@ func testOpenSSL(t *testing.T, context spec.G, it spec.S) {
 
 			source, err = occam.Source(filepath.Join("testdata", "simple_app"))
 			Expect(err).ToNot(HaveOccurred())
+			if settings.Extensions.UbiNodejsExtension.Online != "" {
+				pullPolicy = "always"
+				extenderBuildStr = "[extender (build)] "
+			}
 		})
 
 		it.After(func() {
@@ -66,11 +73,14 @@ func testOpenSSL(t *testing.T, context spec.G, it spec.S) {
 				)
 
 				image, logs, err = pack.WithNoColor().Build.
+					WithExtensions(
+						settings.Extensions.UbiNodejsExtension.Online,
+					).
 					WithBuildpacks(
 						settings.Buildpacks.NodeEngine.Online,
 						settings.Buildpacks.BuildPlan.Online,
 					).
-					WithPullPolicy("never").
+					WithPullPolicy(pullPolicy).
 					WithEnv(map[string]string{
 						"BP_NODE_VERSION": "16.*.*",
 					}).
@@ -88,11 +98,11 @@ func testOpenSSL(t *testing.T, context spec.G, it spec.S) {
 				Expect(container).To(Serve(ContainSubstring("301 Moved")).WithEndpoint("/test-openssl-ca"))
 
 				Expect(logs).To(ContainLines(
-					"  Configuring launch environment",
-					`    NODE_ENV     -> "production"`,
-					fmt.Sprintf(`    NODE_HOME    -> "/layers/%s/node"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
-					`    NODE_OPTIONS -> "--use-openssl-ca"`,
-					`    NODE_VERBOSE -> "false"`,
+					extenderBuildStr+"  Configuring launch environment",
+					extenderBuildStr+`    NODE_ENV     -> "production"`,
+					fmt.Sprintf(`%s    NODE_HOME    -> "/layers/%s/node"`, extenderBuildStr, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
+					extenderBuildStr+`    NODE_OPTIONS -> "--use-openssl-ca"`,
+					extenderBuildStr+`    NODE_VERBOSE -> "false"`,
 				))
 
 			})
@@ -106,11 +116,14 @@ func testOpenSSL(t *testing.T, context spec.G, it spec.S) {
 				)
 
 				image, logs, err = pack.WithNoColor().Build.
+					WithExtensions(
+						settings.Extensions.UbiNodejsExtension.Online,
+					).
 					WithBuildpacks(
 						settings.Buildpacks.NodeEngine.Online,
 						settings.Buildpacks.BuildPlan.Online,
 					).
-					WithPullPolicy("never").
+					WithPullPolicy(pullPolicy).
 					WithEnv(map[string]string{
 						"BP_NODE_VERSION": "18.*.*",
 					}).
@@ -128,11 +141,11 @@ func testOpenSSL(t *testing.T, context spec.G, it spec.S) {
 				Expect(container).To(Serve(ContainSubstring("301 Moved")).WithEndpoint("/test-openssl-ca"))
 
 				Expect(logs).To(ContainLines(
-					"  Configuring launch environment",
-					`    NODE_ENV     -> "production"`,
-					fmt.Sprintf(`    NODE_HOME    -> "/layers/%s/node"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
-					`    NODE_OPTIONS -> "--use-openssl-ca"`,
-					`    NODE_VERBOSE -> "false"`,
+					extenderBuildStr+"  Configuring launch environment",
+					extenderBuildStr+`    NODE_ENV     -> "production"`,
+					fmt.Sprintf(`%s    NODE_HOME    -> "/layers/%s/node"`, extenderBuildStr, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
+					extenderBuildStr+`    NODE_OPTIONS -> "--use-openssl-ca"`,
+					extenderBuildStr+`    NODE_VERBOSE -> "false"`,
 				))
 			})
 		})

--- a/integration/project_path_test.go
+++ b/integration/project_path_test.go
@@ -79,6 +79,20 @@ func testProjectPath(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).ToNot(HaveOccurred(), logs.String)
 
 			if settings.Extensions.UbiNodejsExtension.Online != "" {
+
+				Expect(logs).To(ContainLines(
+					MatchRegexp(`Ubi Node.js Extension \d+\.\d+\.\d+`),
+					"  Resolving Node Engine version",
+					"    Candidate version sources (in priority order):",
+					"      .node-version -> \"18.*\"",
+					"      <unknown>     -> \"\"",
+				))
+
+				Expect(logs).To(ContainLines(
+					"[extender (build)] Enabling module streams:",
+					"[extender (build)]     nodejs:18",
+				))
+
 				Expect(logs).To(ContainLines(
 					fmt.Sprintf("[extender (build)] %s 1.2.3", settings.Buildpack.Name),
 					"[extender (build)]   Resolving Node Engine version",

--- a/integration/project_path_test.go
+++ b/integration/project_path_test.go
@@ -85,7 +85,7 @@ func testProjectPath(t *testing.T, context spec.G, it spec.S) {
 					"  Resolving Node Engine version",
 					"    Candidate version sources (in priority order):",
 					"      .node-version -> \"18.*\"",
-					"      <unknown>     -> \"\"",
+					"      <unknown> -> \"\"",
 				))
 
 				Expect(logs).To(ContainLines(

--- a/integration/project_path_test.go
+++ b/integration/project_path_test.go
@@ -89,11 +89,11 @@ func testProjectPath(t *testing.T, context spec.G, it spec.S) {
 					fmt.Sprintf("%s 1.2.3", settings.Buildpack.Name),
 					"  Resolving Node Engine version",
 					"    Candidate version sources (in priority order):",
-					"      .node-version -> \"16.*\"",
+					"      .node-version -> \"18.*\"",
 					"      <unknown>     -> \"\"",
 				))
 				Expect(logs).To(ContainLines(
-					MatchRegexp(`    Selected Node Engine version \(using \.node-version\): 16\.\d+\.\d+`),
+					MatchRegexp(`    Selected Node Engine version \(using \.node-version\): 18\.\d+\.\d+`),
 				))
 			}
 

--- a/integration/provides_test.go
+++ b/integration/provides_test.go
@@ -31,12 +31,20 @@ func testProvides(t *testing.T, context spec.G, it spec.S) {
 			image  occam.Image
 			name   string
 			source string
+
+			pullPolicy       = "never"
+			extenderBuildStr = ""
 		)
 
 		it.Before(func() {
 			var err error
 			name, err = occam.RandomName()
 			Expect(err).NotTo(HaveOccurred())
+
+			if settings.Extensions.UbiNodejsExtension.Online != "" {
+				pullPolicy = "always"
+				extenderBuildStr = "[extender (build)] "
+			}
 		})
 
 		it.After(func() {
@@ -53,7 +61,10 @@ func testProvides(t *testing.T, context spec.G, it spec.S) {
 
 			var logs fmt.Stringer
 			image, logs, err = pack.WithNoColor().Build.
-				WithPullPolicy("never").
+				WithPullPolicy(pullPolicy).
+				WithExtensions(
+					settings.Extensions.UbiNodejsExtension.Online,
+				).
 				WithBuildpacks(
 					settings.Buildpacks.NodeEngine.Online,
 					settings.Buildpacks.BuildPlan.Online,
@@ -61,42 +72,55 @@ func testProvides(t *testing.T, context spec.G, it spec.S) {
 				Execute(name, source)
 			Expect(err).ToNot(HaveOccurred(), logs.String)
 
+			if settings.Extensions.UbiNodejsExtension.Online != "" {
+
+				Expect(logs).To(ContainLines(
+					fmt.Sprintf("[extender (build)] %s 1.2.3", settings.Buildpack.Name),
+					"[extender (build)]   Resolving Node Engine version",
+					"[extender (build)]   Node no longer requested by plan, satisfied by extension",
+				))
+
+			} else {
+
+				Expect(logs).To(ContainLines(
+					fmt.Sprintf("%s 1.2.3", settings.Buildpack.Name),
+					"  Resolving Node Engine version",
+					"    Candidate version sources (in priority order):",
+					"      <unknown> -> \"\"",
+				))
+				Expect(logs).To(ContainLines(
+					MatchRegexp(`    Selected Node Engine version \(using <unknown>\): 18\.\d+\.\d+`),
+				))
+				Expect(logs).To(ContainLines(
+					"  Executing build process",
+					MatchRegexp(`    Installing Node Engine 18\.\d+\.\d+`),
+					MatchRegexp(`      Completed in \d+(\.\d+)?`),
+				))
+				Expect(logs).To(ContainLines(
+					fmt.Sprintf("  Generating SBOM for /layers/%s/node", strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
+					MatchRegexp(`      Completed in \d+(\.?\d+)*`),
+				))
+
+			}
+
 			Expect(logs).To(ContainLines(
-				fmt.Sprintf("%s 1.2.3", settings.Buildpack.Name),
-				"  Resolving Node Engine version",
-				"    Candidate version sources (in priority order):",
-				"      <unknown> -> \"\"",
+				extenderBuildStr+"  Configuring build environment",
+				extenderBuildStr+`    NODE_ENV     -> "production"`,
+				fmt.Sprintf(`%s    NODE_HOME    -> "/layers/%s/node"`, extenderBuildStr, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
+				extenderBuildStr+`    NODE_OPTIONS -> "--use-openssl-ca"`,
+				extenderBuildStr+`    NODE_VERBOSE -> "false"`,
 			))
 			Expect(logs).To(ContainLines(
-				MatchRegexp(`    Selected Node Engine version \(using <unknown>\): 20\.\d+\.\d+`),
+				extenderBuildStr+"  Configuring launch environment",
+				extenderBuildStr+`    NODE_ENV     -> "production"`,
+				fmt.Sprintf(`%s    NODE_HOME    -> "/layers/%s/node"`, extenderBuildStr, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
+				extenderBuildStr+`    NODE_OPTIONS -> "--use-openssl-ca"`,
+				extenderBuildStr+`    NODE_VERBOSE -> "false"`,
 			))
 			Expect(logs).To(ContainLines(
-				"  Executing build process",
-				MatchRegexp(`    Installing Node Engine 20\.\d+\.\d+`),
-				MatchRegexp(`      Completed in \d+(\.\d+)?`),
-			))
-			Expect(logs).To(ContainLines(
-				fmt.Sprintf("  Generating SBOM for /layers/%s/node", strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
-				MatchRegexp(`      Completed in \d+(\.?\d+)*`),
-			))
-			Expect(logs).To(ContainLines(
-				"  Configuring build environment",
-				`    NODE_ENV     -> "production"`,
-				fmt.Sprintf(`    NODE_HOME    -> "/layers/%s/node"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
-				`    NODE_OPTIONS -> "--use-openssl-ca"`,
-				`    NODE_VERBOSE -> "false"`,
-			))
-			Expect(logs).To(ContainLines(
-				"  Configuring launch environment",
-				`    NODE_ENV     -> "production"`,
-				fmt.Sprintf(`    NODE_HOME    -> "/layers/%s/node"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
-				`    NODE_OPTIONS -> "--use-openssl-ca"`,
-				`    NODE_VERBOSE -> "false"`,
-			))
-			Expect(logs).To(ContainLines(
-				"    Writing exec.d/0-optimize-memory",
-				"      Calculates available memory based on container limits at launch time.",
-				"      Made available in the MEMORY_AVAILABLE environment variable.",
+				extenderBuildStr+"    Writing exec.d/0-optimize-memory",
+				extenderBuildStr+"      Calculates available memory based on container limits at launch time.",
+				extenderBuildStr+"      Made available in the MEMORY_AVAILABLE environment variable.",
 			))
 		})
 	})

--- a/integration/provides_test.go
+++ b/integration/provides_test.go
@@ -79,7 +79,7 @@ func testProvides(t *testing.T, context spec.G, it spec.S) {
 					"  Resolving Node Engine version",
 					"    Candidate version sources (in priority order):",
 					"      .node-version -> \"20.*\"",
-					"      <unknown>     -> \"\"",
+					"      <unknown> -> \"\"",
 				))
 
 				Expect(logs).To(ContainLines(

--- a/integration/provides_test.go
+++ b/integration/provides_test.go
@@ -75,6 +75,19 @@ func testProvides(t *testing.T, context spec.G, it spec.S) {
 			if settings.Extensions.UbiNodejsExtension.Online != "" {
 
 				Expect(logs).To(ContainLines(
+					MatchRegexp(`Ubi Node.js Extension \d+\.\d+\.\d+`),
+					"  Resolving Node Engine version",
+					"    Candidate version sources (in priority order):",
+					"      .node-version -> \"20.*\"",
+					"      <unknown>     -> \"\"",
+				))
+
+				Expect(logs).To(ContainLines(
+					"[extender (build)] Enabling module streams:",
+					"[extender (build)]     nodejs:20",
+				))
+
+				Expect(logs).To(ContainLines(
 					fmt.Sprintf("[extender (build)] %s 1.2.3", settings.Buildpack.Name),
 					"[extender (build)]   Resolving Node Engine version",
 					"[extender (build)]   Node no longer requested by plan, satisfied by extension",
@@ -89,18 +102,17 @@ func testProvides(t *testing.T, context spec.G, it spec.S) {
 					"      <unknown> -> \"\"",
 				))
 				Expect(logs).To(ContainLines(
-					MatchRegexp(`    Selected Node Engine version \(using <unknown>\): 18\.\d+\.\d+`),
+					MatchRegexp(`    Selected Node Engine version \(using <unknown>\): 20\.\d+\.\d+`),
 				))
 				Expect(logs).To(ContainLines(
 					"  Executing build process",
-					MatchRegexp(`    Installing Node Engine 18\.\d+\.\d+`),
+					MatchRegexp(`    Installing Node Engine 20\.\d+\.\d+`),
 					MatchRegexp(`      Completed in \d+(\.\d+)?`),
 				))
 				Expect(logs).To(ContainLines(
 					fmt.Sprintf("  Generating SBOM for /layers/%s/node", strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
 					MatchRegexp(`      Completed in \d+(\.?\d+)*`),
 				))
-
 			}
 
 			Expect(logs).To(ContainLines(

--- a/integration/reuse_layer_rebuild_test.go
+++ b/integration/reuse_layer_rebuild_test.go
@@ -101,7 +101,7 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 					MatchRegexp(`Ubi Node.js Extension \d+\.\d+\.\d+`),
 					"  Resolving Node Engine version",
 					"    Candidate version sources (in priority order):",
-					"      <unknown>     -> \"\"",
+					"      <unknown> -> \"\"",
 				))
 
 				Expect(logs).To(ContainLines(
@@ -191,7 +191,7 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 					MatchRegexp(`Ubi Node.js Extension \d+\.\d+\.\d+`),
 					"  Resolving Node Engine version",
 					"    Candidate version sources (in priority order):",
-					"      <unknown>     -> \"\"",
+					"      <unknown> -> \"\"",
 				))
 
 				Expect(logs).To(ContainLines(
@@ -282,7 +282,7 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 					"  Resolving Node Engine version",
 					"    Candidate version sources (in priority order):",
 					"      .node-version -> \"~18.*\"",
-					"      <unknown>     -> \"\"",
+					"      <unknown> -> \"\"",
 				))
 
 				Expect(logs).To(ContainLines(
@@ -374,7 +374,7 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 					"  Resolving Node Engine version",
 					"    Candidate version sources (in priority order):",
 					"      .node-version -> \"~20.*\"",
-					"      <unknown>     -> \"\"",
+					"      <unknown> -> \"\"",
 				))
 
 				Expect(logs).To(ContainLines(

--- a/integration/reuse_layer_rebuild_test.go
+++ b/integration/reuse_layer_rebuild_test.go
@@ -267,15 +267,15 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 					fmt.Sprintf("%s 1.2.3", settings.Buildpack.Name),
 					"  Resolving Node Engine version",
 					"    Candidate version sources (in priority order):",
-					"      BP_NODE_VERSION -> \"~16\"",
+					"      BP_NODE_VERSION -> \"~18\"",
 					"      <unknown>       -> \"\"",
 				))
 				Expect(logs).To(ContainLines(
-					MatchRegexp(`    Selected Node Engine version \(using BP_NODE_VERSION\): 16\.\d+\.\d+`),
+					MatchRegexp(`    Selected Node Engine version \(using BP_NODE_VERSION\): 18\.\d+\.\d+`),
 				))
 				Expect(logs).To(ContainLines(
 					"  Executing build process",
-					MatchRegexp(`    Installing Node Engine 16\.\d+\.\d+`),
+					MatchRegexp(`    Installing Node Engine 18\.\d+\.\d+`),
 					MatchRegexp(`      Completed in \d+(\.\d+)?`),
 				))
 				Expect(logs).To(ContainLines(

--- a/integration/reuse_layer_rebuild_test.go
+++ b/integration/reuse_layer_rebuild_test.go
@@ -98,11 +98,22 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			if settings.Extensions.UbiNodejsExtension.Online != "" {
 
 				Expect(logs).To(ContainLines(
+					MatchRegexp(`Ubi Node.js Extension \d+\.\d+\.\d+`),
+					"  Resolving Node Engine version",
+					"    Candidate version sources (in priority order):",
+					"      <unknown>     -> \"\"",
+				))
+
+				Expect(logs).To(ContainLines(
+					"[extender (build)] Enabling module streams:",
+					MatchRegexp(`[extender (build)]     nodejs:\d+`),
+				))
+
+				Expect(logs).To(ContainLines(
 					fmt.Sprintf("[extender (build)] %s 1.2.3", settings.Buildpack.Name),
 					"[extender (build)]   Resolving Node Engine version",
 					"[extender (build)]   Node no longer requested by plan, satisfied by extension",
 				))
-
 			} else {
 
 				Expect(logs).To(ContainLines(
@@ -176,6 +187,17 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(secondImage.Buildpacks[0].Layers).To(HaveKey("node"))
 
 			if settings.Extensions.UbiNodejsExtension.Online != "" {
+				Expect(logs).To(ContainLines(
+					MatchRegexp(`Ubi Node.js Extension \d+\.\d+\.\d+`),
+					"  Resolving Node Engine version",
+					"    Candidate version sources (in priority order):",
+					"      <unknown>     -> \"\"",
+				))
+
+				Expect(logs).To(ContainLines(
+					"[extender (build)] Enabling module streams:",
+					MatchRegexp(`[extender (build)]     nodejs:\d+`),
+				))
 
 				Expect(logs).To(ContainLines(
 					fmt.Sprintf("[extender (build)] %s 1.2.3", settings.Buildpack.Name),
@@ -256,13 +278,24 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			if settings.Extensions.UbiNodejsExtension.Online != "" {
 
 				Expect(logs).To(ContainLines(
+					MatchRegexp(`Ubi Node.js Extension \d+\.\d+\.\d+`),
+					"  Resolving Node Engine version",
+					"    Candidate version sources (in priority order):",
+					"      .node-version -> \"~18.*\"",
+					"      <unknown>     -> \"\"",
+				))
+
+				Expect(logs).To(ContainLines(
+					"[extender (build)] Enabling module streams:",
+					"[extender (build)]     nodejs:18",
+				))
+
+				Expect(logs).To(ContainLines(
 					fmt.Sprintf("[extender (build)] %s 1.2.3", settings.Buildpack.Name),
 					"[extender (build)]   Resolving Node Engine version",
 					"[extender (build)]   Node no longer requested by plan, satisfied by extension",
 				))
-
 			} else {
-
 				Expect(logs).To(ContainLines(
 					fmt.Sprintf("%s 1.2.3", settings.Buildpack.Name),
 					"  Resolving Node Engine version",
@@ -337,6 +370,19 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 
 			if settings.Extensions.UbiNodejsExtension.Online != "" {
 				Expect(logs).To(ContainLines(
+					MatchRegexp(`Ubi Node.js Extension \d+\.\d+\.\d+`),
+					"  Resolving Node Engine version",
+					"    Candidate version sources (in priority order):",
+					"      .node-version -> \"~20.*\"",
+					"      <unknown>     -> \"\"",
+				))
+
+				Expect(logs).To(ContainLines(
+					"[extender (build)] Enabling module streams:",
+					"[extender (build)]     nodejs:20",
+				))
+
+				Expect(logs).To(ContainLines(
 					fmt.Sprintf("[extender (build)] %s 1.2.3", settings.Buildpack.Name),
 					"[extender (build)]   Resolving Node Engine version",
 					"[extender (build)]   Node no longer requested by plan, satisfied by extension",
@@ -346,17 +392,17 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 					fmt.Sprintf("%s 1.2.3", settings.Buildpack.Name),
 					"  Resolving Node Engine version",
 					"    Candidate version sources (in priority order):",
-					"      BP_NODE_VERSION -> \"~18\"",
+					"      BP_NODE_VERSION -> \"~20\"",
 					"      <unknown>       -> \"\"",
 				))
 
 				Expect(logs).To(ContainLines(
-					MatchRegexp(`    Selected Node Engine version \(using BP_NODE_VERSION\): 18\.\d+\.\d+`),
+					MatchRegexp(`    Selected Node Engine version \(using BP_NODE_VERSION\): 20\.\d+\.\d+`),
 				))
 
 				Expect(logs).To(ContainLines(
 					"  Executing build process",
-					MatchRegexp(`    Installing Node Engine 18\.\d+\.\d+`),
+					MatchRegexp(`    Installing Node Engine 20\.\d+\.\d+`),
 					MatchRegexp(`      Completed in \d+(\.\d+)?`),
 				))
 				Expect(logs).To(ContainLines(

--- a/integration/simple_app_test.go
+++ b/integration/simple_app_test.go
@@ -95,11 +95,22 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 				if settings.Extensions.UbiNodejsExtension.Online != "" {
 
 					Expect(logs).To(ContainLines(
+						MatchRegexp(`Ubi Node.js Extension \d+\.\d+\.\d+`),
+						"  Resolving Node Engine version",
+						"    Candidate version sources (in priority order):",
+						"      <unknown>     -> \"\"",
+					))
+
+					Expect(logs).To(ContainLines(
+						"[extender (build)] Enabling module streams:",
+						MatchRegexp(`[extender (build)]     nodejs:\d+`),
+					))
+
+					Expect(logs).To(ContainLines(
 						fmt.Sprintf("[extender (build)] %s 1.2.3", settings.Buildpack.Name),
 						"[extender (build)]   Resolving Node Engine version",
 						"[extender (build)]   Node no longer requested by plan, satisfied by extension",
 					))
-
 				} else {
 
 					Expect(logs).To(ContainLines(
@@ -292,7 +303,20 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 
 				if settings.Extensions.UbiNodejsExtension.Online != "" {
 					Expect(logs).To(ContainLines(
-						"[extender (build)] Paketo Buildpack for Node Engine 1.2.3",
+						MatchRegexp(`Ubi Node.js Extension \d+\.\d+\.\d+`),
+						"  Resolving Node Engine version",
+						"    Candidate version sources (in priority order):",
+						"      .node-version -> \"18.*\"",
+						"      <unknown>     -> \"\"",
+					))
+
+					Expect(logs).To(ContainLines(
+						"[extender (build)] Enabling module streams:",
+						"[extender (build)]     nodejs:18",
+					))
+
+					Expect(logs).To(ContainLines(
+						fmt.Sprintf("[extender (build)] %s 1.2.3", settings.Buildpack.Name),
 						"[extender (build)]   Resolving Node Engine version",
 						"[extender (build)]   Node no longer requested by plan, satisfied by extension",
 					))

--- a/integration/simple_app_test.go
+++ b/integration/simple_app_test.go
@@ -92,6 +92,8 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 					Execute(name, source)
 				Expect(err).ToNot(HaveOccurred(), logs.String)
 
+				fmt.Println(logs.String())
+
 				if settings.Extensions.UbiNodejsExtension.Online != "" {
 
 					Expect(logs).To(ContainLines(
@@ -307,7 +309,7 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 						"  Resolving Node Engine version",
 						"    Candidate version sources (in priority order):",
 						"      .node-version -> \"18.*\"",
-						"      <unknown>     -> \"\"",
+						"      <unknown> -> \"\"",
 					))
 
 					Expect(logs).To(ContainLines(

--- a/integration/simple_app_test.go
+++ b/integration/simple_app_test.go
@@ -98,12 +98,12 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 						MatchRegexp(`Ubi Node.js Extension \d+\.\d+\.\d+`),
 						"  Resolving Node Engine version",
 						"    Candidate version sources (in priority order):",
-						"      <unknown>     -> \"\"",
+						"      <unknown> -> \"\"",
 					))
 
 					Expect(logs).To(ContainLines(
 						"[extender (build)] Enabling module streams:",
-						MatchRegexp(`[extender (build)]     nodejs:\d+`),
+						MatchRegexp(`\[extender \(build\)\]     nodejs:\d+`),
 					))
 
 					Expect(logs).To(ContainLines(
@@ -187,24 +187,24 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 				)
 
 				//ubi does not support SBOM for node at the moment
-				if settings.Extensions.UbiNodejsExtension.Online == "" {
-
-					// check that legacy SBOM is included via sbom.legacy.json
-					contents, err := os.ReadFile(filepath.Join(sbomDir, "sbom", "launch", "sbom.legacy.json"))
-					Expect(err).NotTo(HaveOccurred())
-					Expect(string(contents)).To(ContainSubstring(`"name":"Node Engine"`))
-
-					// check that all required SBOM files are present
-					Expect(filepath.Join(sbomDir, "sbom", "launch", strings.ReplaceAll(settings.Buildpack.ID, "/", "_"), "node", "sbom.cdx.json")).To(BeARegularFile())
-					Expect(filepath.Join(sbomDir, "sbom", "launch", strings.ReplaceAll(settings.Buildpack.ID, "/", "_"), "node", "sbom.spdx.json")).To(BeARegularFile())
-					Expect(filepath.Join(sbomDir, "sbom", "launch", strings.ReplaceAll(settings.Buildpack.ID, "/", "_"), "node", "sbom.syft.json")).To(BeARegularFile())
-
-					// check an SBOM file to make sure it has an entry for node
-					contents, err = os.ReadFile(filepath.Join(sbomDir, "sbom", "launch", strings.ReplaceAll(settings.Buildpack.ID, "/", "_"), "node", "sbom.cdx.json"))
-					Expect(err).NotTo(HaveOccurred())
-					Expect(string(contents)).To(ContainSubstring(`"name": "Node Engine"`))
-
+				if settings.Extensions.UbiNodejsExtension.Online != "" {
+					return
 				}
+
+				// check that legacy SBOM is included via sbom.legacy.json
+				contents, err := os.ReadFile(filepath.Join(sbomDir, "sbom", "launch", "sbom.legacy.json"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(contents)).To(ContainSubstring(`"name":"Node Engine"`))
+
+				// check that all required SBOM files are present
+				Expect(filepath.Join(sbomDir, "sbom", "launch", strings.ReplaceAll(settings.Buildpack.ID, "/", "_"), "node", "sbom.cdx.json")).To(BeARegularFile())
+				Expect(filepath.Join(sbomDir, "sbom", "launch", strings.ReplaceAll(settings.Buildpack.ID, "/", "_"), "node", "sbom.spdx.json")).To(BeARegularFile())
+				Expect(filepath.Join(sbomDir, "sbom", "launch", strings.ReplaceAll(settings.Buildpack.ID, "/", "_"), "node", "sbom.syft.json")).To(BeARegularFile())
+
+				// check an SBOM file to make sure it has an entry for node
+				contents, err = os.ReadFile(filepath.Join(sbomDir, "sbom", "launch", strings.ReplaceAll(settings.Buildpack.ID, "/", "_"), "node", "sbom.cdx.json"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(contents)).To(ContainSubstring(`"name": "Node Engine"`))
 			})
 		})
 

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -153,6 +153,7 @@ function tests::run() {
   util::print::title "Run Buildpack Runtime Integration Tests"
   util::print::info "Using ${1} as builder..."
 
+  pack config experimental true
   export CGO_ENABLED=0
   pushd "${BUILDPACKDIR}" > /dev/null
     if GOMAXPROCS="${GOMAXPROCS:-4}" go test -count=1 -timeout 0 ./integration/... -v -run Integration | tee "${2}"; then


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

The goal of this change, is to guarantee that all `node-engine` integration tests run against `ubi-buildpackless-base builder`, that way we ensure that `node-engine` buildpack is able to work on `ubi-buidpackless-base` builder in conjunction with `ubi-nodejs-extension`

## Use Cases
<!-- An explanation of the use cases your change enables -->

This PR adds ubi-buildpackless-base builder on integration tests, more specifically:

* For each integration test we are able test node-engine buildpack against `ubi-buildpackless-base` builder and `ubi-nodejs-extension`
* Conditionaly when building the app, in case `ubi-biuldpackless-base` builder is available we also add `ubi-nodejs-extension`.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
