### PR TITLE
Add an asterisk to the `20.11.0` stack

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -243,7 +243,7 @@ api = "0.7"
     purl = "pkg:generic/node@v20.11.0?checksum=822780369d0ea309e7d218e41debbd1a03f8cdf354ebf8a4420e89f39cc2e612&download_url=https://nodejs.org/dist/v20.11.0/node-v20.11.0-linux-x64.tar.xz"
     source = "https://nodejs.org/dist/v20.11.0/node-v20.11.0-linux-x64.tar.xz"
     source-checksum = "sha256:822780369d0ea309e7d218e41debbd1a03f8cdf354ebf8a4420e89f39cc2e612"
-    stacks = ["io.buildpacks.stacks.jammy"]
+    stacks = ["io.buildpacks.stacks.jammy", "*"]
     strip-components = 1
     uri = "https://nodejs.org/dist/v20.11.0/node-v20.11.0-linux-x64.tar.xz"
     version = "20.11.0"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Adds an asterisk `*` to the Jammy stack for `20.11.0`. This allows for different stacks, like UBI8 or AL2023.

## Use Cases
<!-- An explanation of the use cases your change enables -->

Allows using different stacks. This doesn't correct the [issue with Paketobot not adding an asterisk](https://github.com/paketo-buildpacks/node-engine/issues/855), but it does fix the `20.11.0` stack so that we can build on AL2023.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
