### PR TITLE
add an asterisk to the 20.11.1

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -243,7 +243,7 @@ api = "0.7"
     purl = "pkg:generic/node@v20.11.1?checksum=d8dab549b09672b03356aa2257699f3de3b58c96e74eb26a8b495fbdc9cf6fbe&download_url=https://nodejs.org/dist/v20.11.1/node-v20.11.1-linux-x64.tar.xz"
     source = "https://nodejs.org/dist/v20.11.1/node-v20.11.1-linux-x64.tar.xz"
     source-checksum = "sha256:d8dab549b09672b03356aa2257699f3de3b58c96e74eb26a8b495fbdc9cf6fbe"
-    stacks = ["io.buildpacks.stacks.jammy"]
+    stacks = ["io.buildpacks.stacks.jammy", "*"]
     strip-components = 1
     uri = "https://nodejs.org/dist/v20.11.1/node-v20.11.1-linux-x64.tar.xz"
     version = "20.11.1"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Allow this buildpack to participate in other stacks except jammy.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Related issue
* https://github.com/paketo-buildpacks/node-engine/issues/855
## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
