### PR TITLE
Align module name and version

### DIFF
--- a/build_test.go
+++ b/build_test.go
@@ -8,8 +8,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	nodeengine "github.com/paketo-buildpacks/node-engine"
-	"github.com/paketo-buildpacks/node-engine/fakes"
+	nodeengine "github.com/paketo-buildpacks/node-engine/v3"
+	"github.com/paketo-buildpacks/node-engine/v3/fakes"
 	"github.com/paketo-buildpacks/packit/v2"
 	"github.com/paketo-buildpacks/packit/v2/chronos"
 	"github.com/paketo-buildpacks/packit/v2/scribe"

--- a/cmd/inspector/internal/run_test.go
+++ b/cmd/inspector/internal/run_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/paketo-buildpacks/node-engine/cmd/inspector/internal"
+	"github.com/paketo-buildpacks/node-engine/v3/cmd/inspector/internal"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"

--- a/cmd/inspector/main.go
+++ b/cmd/inspector/main.go
@@ -4,8 +4,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/paketo-buildpacks/node-engine/cmd/inspector/internal"
-	"github.com/paketo-buildpacks/node-engine/cmd/util"
+	"github.com/paketo-buildpacks/node-engine/v3/cmd/inspector/internal"
+	"github.com/paketo-buildpacks/node-engine/v3/cmd/util"
 )
 
 func main() {

--- a/cmd/optimize-memory/internal/run_test.go
+++ b/cmd/optimize-memory/internal/run_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/paketo-buildpacks/node-engine/cmd/optimize-memory/internal"
+	"github.com/paketo-buildpacks/node-engine/v3/cmd/optimize-memory/internal"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"

--- a/cmd/optimize-memory/main.go
+++ b/cmd/optimize-memory/main.go
@@ -4,8 +4,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/paketo-buildpacks/node-engine/cmd/optimize-memory/internal"
-	"github.com/paketo-buildpacks/node-engine/cmd/util"
+	"github.com/paketo-buildpacks/node-engine/v3/cmd/optimize-memory/internal"
+	"github.com/paketo-buildpacks/node-engine/v3/cmd/util"
 )
 
 func main() {

--- a/cmd/util/environment_map_test.go
+++ b/cmd/util/environment_map_test.go
@@ -3,7 +3,7 @@ package util_test
 import (
 	"testing"
 
-	"github.com/paketo-buildpacks/node-engine/cmd/util"
+	"github.com/paketo-buildpacks/node-engine/v3/cmd/util"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"

--- a/dependency/retrieval/go.mod
+++ b/dependency/retrieval/go.mod
@@ -1,4 +1,4 @@
-module github.com/paketo-buildpacks/node-engine/retrieval
+module github.com/paketo-buildpacks/node-engine/v3/retrieval
 
 go 1.19
 

--- a/detect_test.go
+++ b/detect_test.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	nodeengine "github.com/paketo-buildpacks/node-engine"
-	"github.com/paketo-buildpacks/node-engine/fakes"
+	nodeengine "github.com/paketo-buildpacks/node-engine/v3"
+	"github.com/paketo-buildpacks/node-engine/v3/fakes"
 	"github.com/paketo-buildpacks/packit/v2"
 	"github.com/sclevine/spec"
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/paketo-buildpacks/node-engine
+module github.com/paketo-buildpacks/node-engine/v3
 
 go 1.18
 

--- a/node_version_parser_test.go
+++ b/node_version_parser_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	nodeengine "github.com/paketo-buildpacks/node-engine"
+	nodeengine "github.com/paketo-buildpacks/node-engine/v3"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"

--- a/nvmrc_parser_test.go
+++ b/nvmrc_parser_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	nodeengine "github.com/paketo-buildpacks/node-engine"
+	nodeengine "github.com/paketo-buildpacks/node-engine/v3"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"

--- a/run/main.go
+++ b/run/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	nodeengine "github.com/paketo-buildpacks/node-engine"
+	nodeengine "github.com/paketo-buildpacks/node-engine/v3"
 	"github.com/paketo-buildpacks/packit/v2"
 	"github.com/paketo-buildpacks/packit/v2/cargo"
 	"github.com/paketo-buildpacks/packit/v2/chronos"


### PR DESCRIPTION
## Summary

The node-enginge buidpack is currently not following Go's [versioning schema](https://go.dev/doc/modules/release-workflow#breaking) for breaking changes. Other buildpacks, e.g. https://github.com/paketo-buildpacks/procfile, https://github.com/paketo-buildpacks/environment-variables, https://github.com/paketo-buildpacks/sap-machine, are closely following the schema as well. 

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
