### PR TITLE
Remove deprecated node versions 16 and 19

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -16,63 +16,6 @@ api = "0.7"
   [metadata.default-versions]
     node = "20.*.*"
 
-  [[metadata.dependencies]]
-    checksum = "sha256:9d4f5fcafb8e67f5fb251f661d27634bba27899c89b712f84d4fd2bbc89f91ea"
-    cpe = "cpe:2.3:a:nodejs:node.js:16.20.1:*:*:*:*:*:*:*"
-    deprecation_date = "2023-09-11T00:00:00Z"
-    id = "node"
-    licenses = ["0BSD", "Apache-2.0", "Artistic-2.0", "BSD-2-Clause", "BSD-3-Clause", "BSD-4-Clause", "BSD-Source-Code", "CC0-1.0", "ICU", "MIT", "MIT-0", "Unicode-TOU"]
-    name = "Node Engine"
-    purl = "pkg:generic/node@v16.20.1?checksum=b6c60e1e106ad7d8881e83945a5208c1b1d1b63e6901c04b9dafa607aff3a154&download_url=https://nodejs.org/dist/v16.20.1/node-v16.20.1-linux-x64.tar.xz"
-    source = "https://nodejs.org/dist/v16.20.1/node-v16.20.1-linux-x64.tar.xz"
-    source-checksum = "sha256:b6c60e1e106ad7d8881e83945a5208c1b1d1b63e6901c04b9dafa607aff3a154"
-    stacks = ["io.buildpacks.stacks.bionic"]
-    uri = "https://artifacts.paketo.io/node/node_v16.20.1_linux_x64_bionic_9d4f5fca.tgz"
-    version = "16.20.1"
-
-  [[metadata.dependencies]]
-    checksum = "sha256:b6c60e1e106ad7d8881e83945a5208c1b1d1b63e6901c04b9dafa607aff3a154"
-    cpe = "cpe:2.3:a:nodejs:node.js:16.20.1:*:*:*:*:*:*:*"
-    deprecation_date = "2023-09-11T00:00:00Z"
-    id = "node"
-    licenses = ["0BSD", "Apache-2.0", "Artistic-2.0", "BSD-2-Clause", "BSD-3-Clause", "BSD-4-Clause", "BSD-Source-Code", "CC0-1.0", "ICU", "MIT", "MIT-0", "Unicode-TOU"]
-    name = "Node Engine"
-    purl = "pkg:generic/node@v16.20.1?checksum=b6c60e1e106ad7d8881e83945a5208c1b1d1b63e6901c04b9dafa607aff3a154&download_url=https://nodejs.org/dist/v16.20.1/node-v16.20.1-linux-x64.tar.xz"
-    source = "https://nodejs.org/dist/v16.20.1/node-v16.20.1-linux-x64.tar.xz"
-    source-checksum = "sha256:b6c60e1e106ad7d8881e83945a5208c1b1d1b63e6901c04b9dafa607aff3a154"
-    stacks = ["io.buildpacks.stacks.jammy", "*"]
-    strip-components = 1
-    uri = "https://nodejs.org/dist/v16.20.1/node-v16.20.1-linux-x64.tar.xz"
-    version = "16.20.1"
-
-  [[metadata.dependencies]]
-    checksum = "sha256:d51c5b4049043dfb6eee9ba2beddb1438ff2abe70da056a48ae527e123635cf9"
-    cpe = "cpe:2.3:a:nodejs:node.js:16.20.2:*:*:*:*:*:*:*"
-    deprecation_date = "2023-09-11T00:00:00Z"
-    id = "node"
-    licenses = ["0BSD", "Apache-2.0", "Artistic-2.0", "BSD-2-Clause", "BSD-3-Clause", "BSD-4-Clause", "BSD-Source-Code", "CC0-1.0", "ICU", "MIT", "MIT-0", "Unicode-TOU"]
-    name = "Node Engine"
-    purl = "pkg:generic/node@v16.20.2?checksum=874463523f26ed528634580247f403d200ba17a31adf2de98a7b124c6eb33d87&download_url=https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-x64.tar.xz"
-    source = "https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-x64.tar.xz"
-    source-checksum = "sha256:874463523f26ed528634580247f403d200ba17a31adf2de98a7b124c6eb33d87"
-    stacks = ["io.buildpacks.stacks.bionic"]
-    uri = "https://artifacts.paketo.io/node/node_v16.20.2_linux_x64_bionic_d51c5b40.tgz"
-    version = "16.20.2"
-
-  [[metadata.dependencies]]
-    checksum = "sha256:874463523f26ed528634580247f403d200ba17a31adf2de98a7b124c6eb33d87"
-    cpe = "cpe:2.3:a:nodejs:node.js:16.20.2:*:*:*:*:*:*:*"
-    deprecation_date = "2023-09-11T00:00:00Z"
-    id = "node"
-    licenses = ["0BSD", "Apache-2.0", "Artistic-2.0", "BSD-2-Clause", "BSD-3-Clause", "BSD-4-Clause", "BSD-Source-Code", "CC0-1.0", "ICU", "MIT", "MIT-0", "Unicode-TOU"]
-    name = "Node Engine"
-    purl = "pkg:generic/node@v16.20.2?checksum=874463523f26ed528634580247f403d200ba17a31adf2de98a7b124c6eb33d87&download_url=https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-x64.tar.xz"
-    source = "https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-x64.tar.xz"
-    source-checksum = "sha256:874463523f26ed528634580247f403d200ba17a31adf2de98a7b124c6eb33d87"
-    stacks = ["io.buildpacks.stacks.jammy", "*"]
-    strip-components = 1
-    uri = "https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-x64.tar.xz"
-    version = "16.20.2"
 
   [[metadata.dependencies]]
     checksum = "sha256:bd81d33bb3834f06428d101e39ea86bead0ba53a64299ea37b4a77a13811070f"
@@ -133,64 +76,6 @@ api = "0.7"
     version = "18.20.2"
 
   [[metadata.dependencies]]
-    checksum = "sha256:a4269bb04894442de0236b7da13719d911832ad46a6f5d51bf891c7ac2c76b5d"
-    cpe = "cpe:2.3:a:nodejs:node.js:19.8.1:*:*:*:*:*:*:*"
-    deprecation_date = "2023-06-01T00:00:00Z"
-    id = "node"
-    licenses = ["0BSD", "Apache-2.0", "Artistic-2.0", "BSD-2-Clause", "BSD-3-Clause", "BSD-4-Clause", "BSD-Source-Code", "CC0-1.0", "ECL-2.0", "ICU", "MIT", "MIT-0", "SHL-0.5", "SHL-0.51", "Unicode-TOU"]
-    name = "Node Engine"
-    purl = "pkg:generic/node@v19.8.1?checksum=b8ecd95eebda5882bb70c1088595d87a1fd69cc4be81c317191f4f5ebb34b7ac&download_url=https://nodejs.org/dist/v19.8.1/node-v19.8.1-linux-x64.tar.xz"
-    source = "https://nodejs.org/dist/v19.8.1/node-v19.8.1-linux-x64.tar.xz"
-    source-checksum = "sha256:b8ecd95eebda5882bb70c1088595d87a1fd69cc4be81c317191f4f5ebb34b7ac"
-    stacks = ["io.buildpacks.stacks.bionic"]
-    uri = "https://artifacts.paketo.io/node/node_v19.8.1_linux_x64_bionic_a4269bb0.tgz"
-    version = "19.8.1"
-
-  [[metadata.dependencies]]
-    checksum = "sha256:b8ecd95eebda5882bb70c1088595d87a1fd69cc4be81c317191f4f5ebb34b7ac"
-    cpe = "cpe:2.3:a:nodejs:node.js:19.8.1:*:*:*:*:*:*:*"
-    deprecation_date = "2023-06-01T00:00:00Z"
-    id = "node"
-    licenses = ["0BSD", "Apache-2.0", "Artistic-2.0", "BSD-2-Clause", "BSD-3-Clause", "BSD-4-Clause", "BSD-Source-Code", "CC0-1.0", "ECL-2.0", "ICU", "MIT", "MIT-0", "SHL-0.5", "SHL-0.51", "Unicode-TOU"]
-    name = "Node Engine"
-    purl = "pkg:generic/node@v19.8.1?checksum=b8ecd95eebda5882bb70c1088595d87a1fd69cc4be81c317191f4f5ebb34b7ac&download_url=https://nodejs.org/dist/v19.8.1/node-v19.8.1-linux-x64.tar.xz"
-    source = "https://nodejs.org/dist/v19.8.1/node-v19.8.1-linux-x64.tar.xz"
-    source-checksum = "sha256:b8ecd95eebda5882bb70c1088595d87a1fd69cc4be81c317191f4f5ebb34b7ac"
-    stacks = ["io.buildpacks.stacks.jammy", "*"]
-    strip-components = 1
-    uri = "https://nodejs.org/dist/v19.8.1/node-v19.8.1-linux-x64.tar.xz"
-    version = "19.8.1"
-
-  [[metadata.dependencies]]
-    checksum = "sha256:3f5e24807055f5f5da81f4fa9707e7d164fa7d0ad059253923703c20155bbceb"
-    cpe = "cpe:2.3:a:nodejs:node.js:19.9.0:*:*:*:*:*:*:*"
-    deprecation_date = "2023-06-01T00:00:00Z"
-    id = "node"
-    licenses = ["0BSD", "Apache-2.0", "Artistic-2.0", "BSD-2-Clause", "BSD-3-Clause", "BSD-4-Clause", "BSD-Source-Code", "CC0-1.0", "ECL-2.0", "ICU", "MIT", "MIT-0", "SHL-0.5", "SHL-0.51", "Unicode-TOU"]
-    name = "Node Engine"
-    purl = "pkg:generic/node@v19.9.0?checksum=e8ea737ee15a62c8752159d12765ed757b5d4b18036b1011d9e4c9e692a4e58d&download_url=https://nodejs.org/dist/v19.9.0/node-v19.9.0-linux-x64.tar.xz"
-    source = "https://nodejs.org/dist/v19.9.0/node-v19.9.0-linux-x64.tar.xz"
-    source-checksum = "sha256:e8ea737ee15a62c8752159d12765ed757b5d4b18036b1011d9e4c9e692a4e58d"
-    stacks = ["io.buildpacks.stacks.bionic"]
-    uri = "https://artifacts.paketo.io/node/node_v19.9.0_linux_x64_bionic_3f5e2480.tgz"
-    version = "19.9.0"
-
-  [[metadata.dependencies]]
-    checksum = "sha256:e8ea737ee15a62c8752159d12765ed757b5d4b18036b1011d9e4c9e692a4e58d"
-    cpe = "cpe:2.3:a:nodejs:node.js:19.9.0:*:*:*:*:*:*:*"
-    deprecation_date = "2023-06-01T00:00:00Z"
-    id = "node"
-    licenses = ["0BSD", "Apache-2.0", "Artistic-2.0", "BSD-2-Clause", "BSD-3-Clause", "BSD-4-Clause", "BSD-Source-Code", "CC0-1.0", "ECL-2.0", "ICU", "MIT", "MIT-0", "SHL-0.5", "SHL-0.51", "Unicode-TOU"]
-    name = "Node Engine"
-    purl = "pkg:generic/node@v19.9.0?checksum=e8ea737ee15a62c8752159d12765ed757b5d4b18036b1011d9e4c9e692a4e58d&download_url=https://nodejs.org/dist/v19.9.0/node-v19.9.0-linux-x64.tar.xz"
-    source = "https://nodejs.org/dist/v19.9.0/node-v19.9.0-linux-x64.tar.xz"
-    source-checksum = "sha256:e8ea737ee15a62c8752159d12765ed757b5d4b18036b1011d9e4c9e692a4e58d"
-    stacks = ["io.buildpacks.stacks.jammy", "*"]
-    strip-components = 1
-    uri = "https://nodejs.org/dist/v19.9.0/node-v19.9.0-linux-x64.tar.xz"
-    version = "19.9.0"
-
-  [[metadata.dependencies]]
     checksum = "sha256:1c3a6b391824b7152ae3f83343cdee7bc811bf14b3eb24e3ffdfcb84254b74e2"
     cpe = "cpe:2.3:a:nodejs:node.js:20.12.2:*:*:*:*:*:*:*"
     deprecation_date = "2026-04-30T00:00:00Z"
@@ -249,17 +134,7 @@ api = "0.7"
     version = "20.13.0"
 
   [[metadata.dependency-constraints]]
-    constraint = "16.*"
-    id = "node"
-    patches = 2
-
-  [[metadata.dependency-constraints]]
     constraint = "18.*"
-    id = "node"
-    patches = 2
-
-  [[metadata.dependency-constraints]]
-    constraint = "19.*"
     id = "node"
     patches = 2
 

--- a/integration/openssl_test.go
+++ b/integration/openssl_test.go
@@ -58,46 +58,6 @@ func testOpenSSL(t *testing.T, context spec.G, it spec.S) {
 			Expect(os.RemoveAll(sbomDir)).To(Succeed())
 		})
 
-		context("when running Node 16", func() {
-			it("uses the OpenSSL CA store to verify certificates", func() {
-				var (
-					logs fmt.Stringer
-					err  error
-				)
-
-				image, logs, err = pack.WithNoColor().Build.
-					WithBuildpacks(
-						settings.Buildpacks.NodeEngine.Online,
-						settings.Buildpacks.BuildPlan.Online,
-					).
-					WithPullPolicy("never").
-					WithEnv(map[string]string{
-						"BP_NODE_VERSION": "16.*.*",
-					}).
-					Execute(name, source)
-				Expect(err).ToNot(HaveOccurred(), logs.String)
-
-				container, err = docker.Container.Run.
-					WithPublish("8080").
-					WithCommand("node server.js").
-					Execute(image.ID)
-				Expect(err).NotTo(HaveOccurred())
-
-				Eventually(container).Should(Serve("hello world"))
-				Expect(container).To(Serve(ContainSubstring("v16.")).WithEndpoint("/version"))
-				Expect(container).To(Serve(ContainSubstring("301 Moved")).WithEndpoint("/test-openssl-ca"))
-
-				Expect(logs).To(ContainLines(
-					"  Configuring launch environment",
-					`    NODE_ENV     -> "production"`,
-					fmt.Sprintf(`    NODE_HOME    -> "/layers/%s/node"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
-					`    NODE_OPTIONS -> "--use-openssl-ca"`,
-					`    NODE_VERBOSE -> "false"`,
-				))
-
-			})
-		})
-
 		context("when running Node 18", func() {
 			it("uses the OpenSSL CA store to verify certificates", func() {
 				var (


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
According to https://endoflife.date/nodejs, the versions `19` and `16` are not maintained anymore.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
