### PR TITLE
feat: remove deprecated bionic stack and add noble

### DIFF
--- a/dependency/retrieval/main.go
+++ b/dependency/retrieval/main.go
@@ -127,27 +127,28 @@ func createDependencyMetadata(release NodeRelease, releaseSchedule ReleaseSchedu
 		SourceChecksum:  fmt.Sprintf("sha256:%s", checksum),
 		CPE:             fmt.Sprintf("cpe:2.3:a:nodejs:node.js:%s:*:*:*:*:*:*:*", strings.TrimPrefix(version, "v")),
 		PURL:            retrieve.GeneratePURL("node", version, checksum, url),
+		URI:             url,
 		Licenses:        retrieve.LookupLicenses(url, upstream.DefaultDecompress),
 		DeprecationDate: deprecationDate,
-		Stacks:          []string{"io.buildpacks.stacks.bionic"},
+		Stacks:          []string{"io.buildpacks.stacks.jammy"},
 	}
-
-	bionicDependency, err := versionology.NewDependency(dep, "bionic")
-	if err != nil {
-		return nil, fmt.Errorf("could get create bionic dependency: %w", err)
-	}
-
-	dep.Stacks = []string{"io.buildpacks.stacks.jammy", "*"}
-	dep.URI = url
-	dep.Checksum = fmt.Sprintf("sha256:%s", checksum)
-	dep.StripComponents = 1
 
 	jammyDependency, err := versionology.NewDependency(dep, "jammy")
 	if err != nil {
 		return nil, fmt.Errorf("could get create jammy dependency: %w", err)
 	}
 
-	return []versionology.Dependency{bionicDependency, jammyDependency}, nil
+	dep.Stacks = []string{"io.buildpacks.stacks.noble", "*"}
+	dep.URI = url
+	dep.Checksum = fmt.Sprintf("sha256:%s", checksum)
+	dep.StripComponents = 1
+
+	nobleDependency, err := versionology.NewDependency(dep, "noble")
+	if err != nil {
+		return nil, fmt.Errorf("could get create noble dependency: %w", err)
+	}
+
+	return []versionology.Dependency{jammyDependency, nobleDependency}, nil
 }
 
 func getDeprecationDate(version string, releaseSchedule ReleaseSchedule) *time.Time {


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Bionic stack is deprecated and no Node.js no longer builds for it with default tools, remove it.

Add noble stack

This should fix: https://github.com/paketo-buildpacks/node-engine/issues/617 as we only compile Node right now on bionic.

It think it will also obsolete https://github.com/paketo-buildpacks/node-engine/issues/585 since we won't be compiling node.js anymore.




## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
