### PR TITLE
Requiring python during build time in case is not available on the build image

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -1,8 +1,9 @@
 package nodeengine
 
 const (
-	Node = "node"
-	Npm  = "npm"
+	Node    = "node"
+	Npm     = "npm"
+	Cpython = "cpython"
 
 	DepKey             = "dependency-sha"
 	BuildKey           = "build"

--- a/integration.json
+++ b/integration.json
@@ -1,6 +1,8 @@
 {
   "build-plan": "github.com/paketo-community/build-plan",
   "builders": [
-    "index.docker.io/paketobuildpacks/builder-jammy-buildpackless-base:latest"
-  ]
+    "index.docker.io/paketobuildpacks/builder-jammy-buildpackless-base:latest",
+    "index.docker.io/paketobuildpacks/ubuntu-noble-builder-buildpackless:latest"
+  ],
+  "cpython": "github.com/paketo-buildpacks/cpython"
 }

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -30,7 +30,8 @@ var settings struct {
 			Online string
 		}
 		Cpython struct {
-			Online string
+			Online  string
+			Offline string
 		}
 	}
 
@@ -78,6 +79,11 @@ func TestIntegration(t *testing.T) {
 	Expect(err).NotTo(HaveOccurred())
 
 	settings.Buildpacks.Cpython.Online, err = buildpackStore.Get.
+		Execute(settings.Config.Cpython)
+	Expect(err).ToNot(HaveOccurred())
+
+	settings.Buildpacks.Cpython.Offline, err = buildpackStore.Get.
+		WithOfflineDependencies().
 		Execute(settings.Config.Cpython)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -29,6 +29,9 @@ var settings struct {
 		Processes struct {
 			Online string
 		}
+		Cpython struct {
+			Online string
+		}
 	}
 
 	Buildpack struct {
@@ -38,6 +41,7 @@ var settings struct {
 
 	Config struct {
 		BuildPlan string `json:"build-plan"`
+		Cpython   string `json:"cpython"`
 	}
 }
 
@@ -72,6 +76,10 @@ func TestIntegration(t *testing.T) {
 		WithVersion("1.2.3").
 		Execute(root)
 	Expect(err).NotTo(HaveOccurred())
+
+	settings.Buildpacks.Cpython.Online, err = buildpackStore.Get.
+		Execute(settings.Config.Cpython)
+	Expect(err).ToNot(HaveOccurred())
 
 	tmpBuildpackDir, err := os.MkdirTemp("", "node-engine-outdated-deps")
 	Expect(err).NotTo(HaveOccurred())

--- a/integration/inspector_test.go
+++ b/integration/inspector_test.go
@@ -52,6 +52,7 @@ func testInspector(t *testing.T, context spec.G, it spec.S) {
 		image, logs, err = pack.WithNoColor().Build.
 			WithPullPolicy("never").
 			WithBuildpacks(
+				settings.Buildpacks.Cpython.Online,
 				settings.Buildpacks.NodeEngine.Online,
 				settings.Buildpacks.Processes.Online,
 			).

--- a/integration/offline_test.go
+++ b/integration/offline_test.go
@@ -56,7 +56,7 @@ func testOffline(t *testing.T, context spec.G, it spec.S) {
 			image, logs, err = pack.WithNoColor().Build.
 				WithPullPolicy("never").
 				WithBuildpacks(
-					settings.Buildpacks.Cpython.Online,
+					settings.Buildpacks.Cpython.Offline,
 					settings.Buildpacks.NodeEngine.Offline,
 					settings.Buildpacks.BuildPlan.Online,
 				).

--- a/integration/offline_test.go
+++ b/integration/offline_test.go
@@ -56,6 +56,7 @@ func testOffline(t *testing.T, context spec.G, it spec.S) {
 			image, logs, err = pack.WithNoColor().Build.
 				WithPullPolicy("never").
 				WithBuildpacks(
+					settings.Buildpacks.Cpython.Online,
 					settings.Buildpacks.NodeEngine.Offline,
 					settings.Buildpacks.BuildPlan.Online,
 				).

--- a/integration/openssl_test.go
+++ b/integration/openssl_test.go
@@ -67,6 +67,7 @@ func testOpenSSL(t *testing.T, context spec.G, it spec.S) {
 
 				image, logs, err = pack.WithNoColor().Build.
 					WithBuildpacks(
+						settings.Buildpacks.Cpython.Online,
 						settings.Buildpacks.NodeEngine.Online,
 						settings.Buildpacks.BuildPlan.Online,
 					).
@@ -106,6 +107,7 @@ func testOpenSSL(t *testing.T, context spec.G, it spec.S) {
 
 				image, logs, err = pack.WithNoColor().Build.
 					WithBuildpacks(
+						settings.Buildpacks.Cpython.Online,
 						settings.Buildpacks.NodeEngine.Online,
 						settings.Buildpacks.BuildPlan.Online,
 					).

--- a/integration/optimize_memory_test.go
+++ b/integration/optimize_memory_test.go
@@ -53,6 +53,7 @@ func testOptimizeMemory(t *testing.T, context spec.G, it spec.S) {
 		image, logs, err = pack.WithNoColor().Build.
 			WithPullPolicy("never").
 			WithBuildpacks(
+				settings.Buildpacks.Cpython.Online,
 				settings.Buildpacks.NodeEngine.Online,
 				settings.Buildpacks.Processes.Online,
 			).

--- a/integration/project_path_test.go
+++ b/integration/project_path_test.go
@@ -60,6 +60,7 @@ func testProjectPath(t *testing.T, context spec.G, it spec.S) {
 			image, logs, err = pack.WithNoColor().Build.
 				WithPullPolicy("never").
 				WithBuildpacks(
+					settings.Buildpacks.Cpython.Online,
 					settings.Buildpacks.NodeEngine.Online,
 					settings.Buildpacks.BuildPlan.Online,
 				).

--- a/integration/provides_test.go
+++ b/integration/provides_test.go
@@ -55,6 +55,7 @@ func testProvides(t *testing.T, context spec.G, it spec.S) {
 			image, logs, err = pack.WithNoColor().Build.
 				WithPullPolicy("never").
 				WithBuildpacks(
+					settings.Buildpacks.Cpython.Online,
 					settings.Buildpacks.NodeEngine.Online,
 					settings.Buildpacks.BuildPlan.Online,
 				).

--- a/integration/reuse_layer_rebuild_test.go
+++ b/integration/reuse_layer_rebuild_test.go
@@ -72,6 +72,7 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			firstImage, logs, err = pack.WithNoColor().Build.
 				WithPullPolicy("never").
 				WithBuildpacks(
+					settings.Buildpacks.Cpython.Online,
 					settings.Buildpacks.NodeEngine.Online,
 					settings.Buildpacks.BuildPlan.Online,
 				).
@@ -137,6 +138,7 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			secondImage, logs, err = pack.WithNoColor().Build.
 				WithPullPolicy("never").
 				WithBuildpacks(
+					settings.Buildpacks.Cpython.Online,
 					settings.Buildpacks.NodeEngine.Online,
 					settings.Buildpacks.BuildPlan.Online,
 				).
@@ -203,6 +205,7 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			firstImage, logs, err = pack.WithNoColor().Build.
 				WithPullPolicy("never").
 				WithBuildpacks(
+					settings.Buildpacks.Cpython.Online,
 					settings.Buildpacks.NodeEngine.Online,
 					settings.Buildpacks.BuildPlan.Online,
 				).
@@ -270,6 +273,7 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			secondImage, logs, err = pack.WithNoColor().Build.
 				WithPullPolicy("never").
 				WithBuildpacks(
+					settings.Buildpacks.Cpython.Online,
 					settings.Buildpacks.NodeEngine.Online,
 					settings.Buildpacks.BuildPlan.Online,
 				).

--- a/integration/reuse_layer_rebuild_test.go
+++ b/integration/reuse_layer_rebuild_test.go
@@ -81,7 +81,6 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 
 			imageIDs[firstImage.ID] = struct{}{}
 
-			//print first image content
 
 			Expect(firstImage.Buildpacks).To(HaveLen(3))
 			Expect(firstImage.Buildpacks[1].Key).To(Equal(settings.Buildpack.ID))

--- a/integration/reuse_layer_rebuild_test.go
+++ b/integration/reuse_layer_rebuild_test.go
@@ -81,9 +81,11 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 
 			imageIDs[firstImage.ID] = struct{}{}
 
-			Expect(firstImage.Buildpacks).To(HaveLen(2))
-			Expect(firstImage.Buildpacks[0].Key).To(Equal(settings.Buildpack.ID))
-			Expect(firstImage.Buildpacks[0].Layers).To(HaveKey("node"))
+			//print first image content
+
+			Expect(firstImage.Buildpacks).To(HaveLen(3))
+			Expect(firstImage.Buildpacks[1].Key).To(Equal(settings.Buildpack.ID))
+			Expect(firstImage.Buildpacks[1].Layers).To(HaveKey("node"))
 
 			Expect(logs).To(ContainLines(
 				fmt.Sprintf("%s 1.2.3", settings.Buildpack.Name),
@@ -147,9 +149,9 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 
 			imageIDs[secondImage.ID] = struct{}{}
 
-			Expect(secondImage.Buildpacks).To(HaveLen(2))
-			Expect(secondImage.Buildpacks[0].Key).To(Equal(settings.Buildpack.ID))
-			Expect(secondImage.Buildpacks[0].Layers).To(HaveKey("node"))
+			Expect(secondImage.Buildpacks).To(HaveLen(3))
+			Expect(secondImage.Buildpacks[1].Key).To(Equal(settings.Buildpack.ID))
+			Expect(secondImage.Buildpacks[1].Layers).To(HaveKey("node"))
 
 			Expect(logs).To(ContainLines(
 				fmt.Sprintf("%s 1.2.3", settings.Buildpack.Name),
@@ -183,7 +185,8 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(content).To(ContainSubstring("hello world"))
 
-			Expect(secondImage.Buildpacks[0].Layers["node"].SHA).To(Equal(firstImage.Buildpacks[0].Layers["node"].SHA))
+			Expect(secondImage.Buildpacks[0].Layers["cpython"].SHA).To(Equal(firstImage.Buildpacks[0].Layers["cpython"].SHA))
+			Expect(secondImage.Buildpacks[1].Layers["node"].SHA).To(Equal(firstImage.Buildpacks[1].Layers["node"].SHA))
 		})
 	})
 
@@ -215,9 +218,9 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 
 			imageIDs[firstImage.ID] = struct{}{}
 
-			Expect(firstImage.Buildpacks).To(HaveLen(2))
-			Expect(firstImage.Buildpacks[0].Key).To(Equal(settings.Buildpack.ID))
-			Expect(firstImage.Buildpacks[0].Layers).To(HaveKey("node"))
+			Expect(firstImage.Buildpacks).To(HaveLen(3))
+			Expect(firstImage.Buildpacks[1].Key).To(Equal(settings.Buildpack.ID))
+			Expect(firstImage.Buildpacks[1].Layers).To(HaveKey("node"))
 
 			Expect(logs).To(ContainLines(
 				fmt.Sprintf("%s 1.2.3", settings.Buildpack.Name),
@@ -283,9 +286,9 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 
 			imageIDs[secondImage.ID] = struct{}{}
 
-			Expect(secondImage.Buildpacks).To(HaveLen(2))
-			Expect(secondImage.Buildpacks[0].Key).To(Equal(settings.Buildpack.ID))
-			Expect(secondImage.Buildpacks[0].Layers).To(HaveKey("node"))
+			Expect(secondImage.Buildpacks).To(HaveLen(3))
+			Expect(secondImage.Buildpacks[1].Key).To(Equal(settings.Buildpack.ID))
+			Expect(secondImage.Buildpacks[1].Layers).To(HaveKey("node"))
 
 			Expect(logs).To(ContainLines(
 				fmt.Sprintf("%s 1.2.3", settings.Buildpack.Name),
@@ -345,7 +348,7 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(content).To(ContainSubstring("hello world"))
 
-			Expect(secondImage.Buildpacks[0].Layers["node"].SHA).NotTo(Equal(firstImage.Buildpacks[0].Layers["node"].SHA))
+			Expect(secondImage.Buildpacks[1].Layers["node"].SHA).NotTo(Equal(firstImage.Buildpacks[1].Layers["node"].SHA))
 		})
 	})
 }

--- a/integration/simple_app_test.go
+++ b/integration/simple_app_test.go
@@ -71,6 +71,7 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 				image, logs, err = pack.WithNoColor().Build.
 					WithPullPolicy("never").
 					WithBuildpacks(
+						settings.Buildpacks.Cpython.Online,
 						settings.Buildpacks.NodeEngine.Online,
 						settings.Buildpacks.BuildPlan.Online,
 					).
@@ -183,6 +184,7 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 					WithPullPolicy("never").
 					WithEnv(map[string]string{"NODE_ENV": "development", "NODE_VERBOSE": "true"}).
 					WithBuildpacks(
+						settings.Buildpacks.Cpython.Online,
 						settings.Buildpacks.NodeEngine.Online,
 						settings.Buildpacks.BuildPlan.Online,
 					).
@@ -248,6 +250,7 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 				image, logs, err = pack.WithNoColor().Build.
 					WithPullPolicy("never").
 					WithBuildpacks(
+						settings.Buildpacks.Cpython.Online,
 						settings.Buildpacks.NodeEngine.Online,
 						settings.Buildpacks.BuildPlan.Online,
 					).
@@ -334,6 +337,7 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 				image, logs, err = pack.WithNoColor().Build.
 					WithPullPolicy("never").
 					WithBuildpacks(
+						settings.Buildpacks.Cpython.Online,
 						settings.Buildpacks.NodeEngine.Online,
 						settings.Buildpacks.BuildPlan.Online,
 					).
@@ -415,6 +419,7 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 				image, logs, err = pack.WithNoColor().Build.
 					WithPullPolicy("never").
 					WithBuildpacks(
+						settings.Buildpacks.Cpython.Online,
 						settings.Buildpacks.NodeEngine.Deprecated,
 						settings.Buildpacks.BuildPlan.Online,
 					).
@@ -443,6 +448,7 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 				image, logs, err = pack.WithNoColor().Build.
 					WithPullPolicy("never").
 					WithBuildpacks(
+						settings.Buildpacks.Cpython.Online,
 						settings.Buildpacks.NodeEngine.Online,
 						settings.Buildpacks.BuildPlan.Online,
 					).


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Merge After 
https://github.com/paketo-buildpacks/nodejs/pull/1215

## Summary
<!-- A short explanation of the proposed change -->
This PR requires cpython for installing python binaries in non rhel distributions, as the base build image does not include python on non rhel distributions. This is necessary for npm-install in case it has to compile native modules.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
