### PR TITLE
Env variable for explicitly excluding cpython in participating during build

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ## `docker.io/paketobuildpacks/node-engine`
 
-The Node Engine CNB provides the Node binary distribution.  The buildpack
+The Node Engine CNB provides the Node binary distribution. The buildpack
 installs the Node binary distribution onto the `$PATH` which makes it available
-for subsequent buildpacks and in the final running container.  Examples of
+for subsequent buildpacks and in the final running container. Examples of
 buildpacks that might use the Node binary distribution are the [NPM
 CNB](https://github.com/paketo-buildpacks/npm) and [Yarn Install
 CNB](https://github.com/paketo-buildpacks/yarn-install)
@@ -148,6 +148,13 @@ the `BP_NODE_PROJECT_PATH` environment variable at build time either directly
 file](https://github.com/buildpacks/spec/blob/main/extensions/project-descriptor.md).
 This could be useful if your app is a part of a monorepo.
 
+### Exclude python installation during the build process
+
+To exclude the participation of the cpython during the build process, please use
+the `BP_NODE_EXCLUDE_BUILD_PYTHON` environment variable at build time either directly (ex. `pack build my-app --env BP_NODE_EXCLUDE_BUILD_PYTHON`).
+
+This will skip the installation of python during the build process on the build base image, by not requiring the cpython buildpack through the build plan.
+
 ### Enabling Inspector for Remote Debugging
 
 To enable the Inspector set the `BPL_DEBUG_ENABLED` environment variable at launch time. Optionally, you can specify the `BPL_DEBUG_PORT` environment variable to use a specific port.
@@ -162,11 +169,13 @@ For more information on debugging, see [Official Documentation](https://nodejs.o
 ## Run Tests
 
 To run all unit tests, run:
+
 ```
 ./scripts/unit.sh
 ```
 
 To run all integration tests, run:
+
 ```
 /scripts/integration.sh
 ```

--- a/detect_test.go
+++ b/detect_test.go
@@ -279,6 +279,161 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		})
 	})
 
+	context("when $BP_NODE_EXCLUDE_BUILD_PYTHON is NOT set", func() {
+		var pathEntries string
+		it.Before(func() {
+			pathEntries = os.Getenv("PATH")
+			os.Setenv("PATH", "")
+		})
+
+		it.After(func() {
+			os.Setenv("PATH", pathEntries)
+		})
+		it("and python does NOT exist on the path, it includes cpython buildpack", func() {
+
+			result, err := detect(packit.DetectContext{
+				WorkingDir: "/working-dir",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Plan).To(Equal(packit.BuildPlan{
+				Provides: []packit.BuildPlanProvision{
+					{Name: nodeengine.Node},
+				},
+				Requires: []packit.BuildPlanRequirement{
+					{
+						Name: nodeengine.Cpython,
+						Metadata: nodeengine.BuildPlanMetadata{
+							Build:  true,
+							Launch: false,
+						},
+					},
+				},
+				Or: []packit.BuildPlan{
+					{
+						Provides: []packit.BuildPlanProvision{
+							{Name: nodeengine.Node},
+							{Name: nodeengine.Npm},
+						},
+						Requires: []packit.BuildPlanRequirement{
+							{
+								Name: nodeengine.Cpython,
+								Metadata: nodeengine.BuildPlanMetadata{
+									Build:  true,
+									Launch: false,
+								},
+							},
+						},
+					},
+				},
+			}))
+
+		})
+	})
+
+	context("when $BP_NODE_EXCLUDE_BUILD_PYTHON is NOT set", func() {
+
+		var pathEntries string
+		it.Before(func() {
+			pathEntries = os.Getenv("PATH")
+			os.Setenv("PATH", pathEntries+":/some/path/to/python")
+		})
+
+		it.After(func() {
+			os.Setenv("PATH", pathEntries)
+		})
+		it("and python does exists on the path, it does NOT include on the plan", func() {
+
+			result, err := detect(packit.DetectContext{
+				WorkingDir: "/working-dir",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Plan).To(Equal(packit.BuildPlan{
+				Provides: []packit.BuildPlanProvision{
+					{Name: nodeengine.Node},
+				},
+				Or: []packit.BuildPlan{
+					{
+						Provides: []packit.BuildPlanProvision{
+							{Name: nodeengine.Node},
+							{Name: nodeengine.Npm},
+						},
+					},
+				},
+			}))
+		})
+	})
+
+	context("when $BP_NODE_EXCLUDE_BUILD_PYTHON is set", func() {
+		var pathEntries string
+		it.Before(func() {
+			pathEntries = os.Getenv("PATH")
+			os.Setenv("BP_NODE_EXCLUDE_BUILD_PYTHON", "true")
+			os.Setenv("PATH", "")
+		})
+
+		it.After(func() {
+			os.Setenv("PATH", pathEntries)
+			os.Unsetenv("BP_NODE_EXCLUDE_BUILD_PYTHON")
+		})
+
+		it("and python does NOT exist on the path, it does NOT include cpython buildpack", func() {
+
+			result, err := detect(packit.DetectContext{
+				WorkingDir: "/working-dir",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Plan).To(Equal(packit.BuildPlan{
+				Provides: []packit.BuildPlanProvision{
+					{Name: nodeengine.Node},
+				},
+				Or: []packit.BuildPlan{
+					{
+						Provides: []packit.BuildPlanProvision{
+							{Name: nodeengine.Node},
+							{Name: nodeengine.Npm},
+						},
+					},
+				},
+			}))
+		})
+
+	})
+	context("when $BP_NODE_EXCLUDE_BUILD_PYTHON is set", func() {
+
+		var pathEntries string
+		it.Before(func() {
+			pathEntries = os.Getenv("PATH")
+			os.Setenv("BP_NODE_EXCLUDE_BUILD_PYTHON", "true")
+			os.Setenv("PATH", pathEntries+":/some/path/to/python")
+		})
+
+		it.After(func() {
+			os.Setenv("PATH", pathEntries)
+			os.Unsetenv("BP_NODE_EXCLUDE_BUILD_PYTHON")
+		})
+		it("and python exists on the path, it does NOT include cpython buildpack", func() {
+
+			result, err := detect(packit.DetectContext{
+				WorkingDir: "/working-dir",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Plan).To(Equal(packit.BuildPlan{
+				Provides: []packit.BuildPlanProvision{
+					{Name: nodeengine.Node},
+				},
+				Or: []packit.BuildPlan{
+					{
+						Provides: []packit.BuildPlanProvision{
+							{Name: nodeengine.Node},
+							{Name: nodeengine.Npm},
+						},
+					},
+				},
+			}))
+
+		})
+	})
+
 	context("failure cases", func() {
 		context("when the dir specified by BP_NODE_PROJECT_PATH does not exist", func() {
 			var workingDir string

--- a/integration/inspector_test.go
+++ b/integration/inspector_test.go
@@ -52,10 +52,12 @@ func testInspector(t *testing.T, context spec.G, it spec.S) {
 		image, logs, err = pack.WithNoColor().Build.
 			WithPullPolicy("never").
 			WithBuildpacks(
-				settings.Buildpacks.Cpython.Online,
 				settings.Buildpacks.NodeEngine.Online,
 				settings.Buildpacks.Processes.Online,
 			).
+			WithEnv(map[string]string{
+				"BP_NODE_EXCLUDE_BUILD_PYTHON": "",
+			}).
 			Execute(name, source)
 
 		Expect(err).NotTo(HaveOccurred())

--- a/integration/openssl_test.go
+++ b/integration/openssl_test.go
@@ -67,13 +67,13 @@ func testOpenSSL(t *testing.T, context spec.G, it spec.S) {
 
 				image, logs, err = pack.WithNoColor().Build.
 					WithBuildpacks(
-						settings.Buildpacks.Cpython.Online,
 						settings.Buildpacks.NodeEngine.Online,
 						settings.Buildpacks.BuildPlan.Online,
 					).
 					WithPullPolicy("never").
 					WithEnv(map[string]string{
-						"BP_NODE_VERSION": "20.*.*",
+						"BP_NODE_VERSION":              "20.*.*",
+						"BP_NODE_EXCLUDE_BUILD_PYTHON": "",
 					}).
 					Execute(name, source)
 				Expect(err).ToNot(HaveOccurred(), logs.String)
@@ -107,13 +107,13 @@ func testOpenSSL(t *testing.T, context spec.G, it spec.S) {
 
 				image, logs, err = pack.WithNoColor().Build.
 					WithBuildpacks(
-						settings.Buildpacks.Cpython.Online,
 						settings.Buildpacks.NodeEngine.Online,
 						settings.Buildpacks.BuildPlan.Online,
 					).
 					WithPullPolicy("never").
 					WithEnv(map[string]string{
-						"BP_NODE_VERSION": "20.*.*",
+						"BP_NODE_VERSION":              "20.*.*",
+						"BP_NODE_EXCLUDE_BUILD_PYTHON": "",
 					}).
 					Execute(name, source)
 				Expect(err).ToNot(HaveOccurred(), logs.String)

--- a/integration/optimize_memory_test.go
+++ b/integration/optimize_memory_test.go
@@ -53,11 +53,13 @@ func testOptimizeMemory(t *testing.T, context spec.G, it spec.S) {
 		image, logs, err = pack.WithNoColor().Build.
 			WithPullPolicy("never").
 			WithBuildpacks(
-				settings.Buildpacks.Cpython.Online,
 				settings.Buildpacks.NodeEngine.Online,
 				settings.Buildpacks.Processes.Online,
 			).
-			WithEnv(map[string]string{"BP_NODE_OPTIMIZE_MEMORY": "true"}).
+			WithEnv(map[string]string{
+				"BP_NODE_OPTIMIZE_MEMORY":      "true",
+				"BP_NODE_EXCLUDE_BUILD_PYTHON": "",
+			}).
 			Execute(name, source)
 
 		Expect(err).NotTo(HaveOccurred())

--- a/integration/project_path_test.go
+++ b/integration/project_path_test.go
@@ -60,12 +60,12 @@ func testProjectPath(t *testing.T, context spec.G, it spec.S) {
 			image, logs, err = pack.WithNoColor().Build.
 				WithPullPolicy("never").
 				WithBuildpacks(
-					settings.Buildpacks.Cpython.Online,
 					settings.Buildpacks.NodeEngine.Online,
 					settings.Buildpacks.BuildPlan.Online,
 				).
 				WithEnv(map[string]string{
-					"BP_NODE_PROJECT_PATH": "hello_world_server",
+					"BP_NODE_PROJECT_PATH":         "hello_world_server",
+					"BP_NODE_EXCLUDE_BUILD_PYTHON": "",
 				}).
 				Execute(name, source)
 			Expect(err).ToNot(HaveOccurred(), logs.String)

--- a/integration/provides_test.go
+++ b/integration/provides_test.go
@@ -55,10 +55,12 @@ func testProvides(t *testing.T, context spec.G, it spec.S) {
 			image, logs, err = pack.WithNoColor().Build.
 				WithPullPolicy("never").
 				WithBuildpacks(
-					settings.Buildpacks.Cpython.Online,
 					settings.Buildpacks.NodeEngine.Online,
 					settings.Buildpacks.BuildPlan.Online,
 				).
+				WithEnv(map[string]string{
+					"BP_NODE_EXCLUDE_BUILD_PYTHON": "",
+				}).
 				Execute(name, source)
 			Expect(err).ToNot(HaveOccurred(), logs.String)
 

--- a/integration/reuse_layer_rebuild_test.go
+++ b/integration/reuse_layer_rebuild_test.go
@@ -72,19 +72,19 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			firstImage, logs, err = pack.WithNoColor().Build.
 				WithPullPolicy("never").
 				WithBuildpacks(
-					settings.Buildpacks.Cpython.Online,
 					settings.Buildpacks.NodeEngine.Online,
 					settings.Buildpacks.BuildPlan.Online,
 				).
+				WithEnv(map[string]string{"BP_NODE_EXCLUDE_BUILD_PYTHON": ""}).
 				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred())
 
 			imageIDs[firstImage.ID] = struct{}{}
 
 
-			Expect(firstImage.Buildpacks).To(HaveLen(3))
-			Expect(firstImage.Buildpacks[1].Key).To(Equal(settings.Buildpack.ID))
-			Expect(firstImage.Buildpacks[1].Layers).To(HaveKey("node"))
+			Expect(firstImage.Buildpacks).To(HaveLen(2))
+			Expect(firstImage.Buildpacks[0].Key).To(Equal(settings.Buildpack.ID))
+			Expect(firstImage.Buildpacks[0].Layers).To(HaveKey("node"))
 
 			Expect(logs).To(ContainLines(
 				fmt.Sprintf("%s 1.2.3", settings.Buildpack.Name),
@@ -139,18 +139,18 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			secondImage, logs, err = pack.WithNoColor().Build.
 				WithPullPolicy("never").
 				WithBuildpacks(
-					settings.Buildpacks.Cpython.Online,
 					settings.Buildpacks.NodeEngine.Online,
 					settings.Buildpacks.BuildPlan.Online,
 				).
+				WithEnv(map[string]string{"BP_NODE_EXCLUDE_BUILD_PYTHON": ""}).
 				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred())
 
 			imageIDs[secondImage.ID] = struct{}{}
 
-			Expect(secondImage.Buildpacks).To(HaveLen(3))
-			Expect(secondImage.Buildpacks[1].Key).To(Equal(settings.Buildpack.ID))
-			Expect(secondImage.Buildpacks[1].Layers).To(HaveKey("node"))
+			Expect(secondImage.Buildpacks).To(HaveLen(2))
+			Expect(secondImage.Buildpacks[0].Key).To(Equal(settings.Buildpack.ID))
+			Expect(secondImage.Buildpacks[0].Layers).To(HaveKey("node"))
 
 			Expect(logs).To(ContainLines(
 				fmt.Sprintf("%s 1.2.3", settings.Buildpack.Name),
@@ -184,8 +184,7 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(content).To(ContainSubstring("hello world"))
 
-			Expect(secondImage.Buildpacks[0].Layers["cpython"].SHA).To(Equal(firstImage.Buildpacks[0].Layers["cpython"].SHA))
-			Expect(secondImage.Buildpacks[1].Layers["node"].SHA).To(Equal(firstImage.Buildpacks[1].Layers["node"].SHA))
+			Expect(secondImage.Buildpacks[0].Layers["node"].SHA).To(Equal(firstImage.Buildpacks[0].Layers["node"].SHA))
 		})
 	})
 
@@ -207,19 +206,21 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			firstImage, logs, err = pack.WithNoColor().Build.
 				WithPullPolicy("never").
 				WithBuildpacks(
-					settings.Buildpacks.Cpython.Online,
 					settings.Buildpacks.NodeEngine.Online,
 					settings.Buildpacks.BuildPlan.Online,
 				).
-				WithEnv(map[string]string{"BP_NODE_VERSION": "~20"}).
+				WithEnv(map[string]string{
+					"BP_NODE_VERSION":              "~20",
+					"BP_NODE_EXCLUDE_BUILD_PYTHON": "",
+				}).
 				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred())
 
 			imageIDs[firstImage.ID] = struct{}{}
 
-			Expect(firstImage.Buildpacks).To(HaveLen(3))
-			Expect(firstImage.Buildpacks[1].Key).To(Equal(settings.Buildpack.ID))
-			Expect(firstImage.Buildpacks[1].Layers).To(HaveKey("node"))
+			Expect(firstImage.Buildpacks).To(HaveLen(2))
+			Expect(firstImage.Buildpacks[0].Key).To(Equal(settings.Buildpack.ID))
+			Expect(firstImage.Buildpacks[0].Layers).To(HaveKey("node"))
 
 			Expect(logs).To(ContainLines(
 				fmt.Sprintf("%s 1.2.3", settings.Buildpack.Name),
@@ -275,19 +276,21 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			secondImage, logs, err = pack.WithNoColor().Build.
 				WithPullPolicy("never").
 				WithBuildpacks(
-					settings.Buildpacks.Cpython.Online,
 					settings.Buildpacks.NodeEngine.Online,
 					settings.Buildpacks.BuildPlan.Online,
 				).
-				WithEnv(map[string]string{"BP_NODE_VERSION": "~22"}).
+				WithEnv(map[string]string{
+					"BP_NODE_VERSION":              "~22",
+					"BP_NODE_EXCLUDE_BUILD_PYTHON": "",
+				}).
 				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred())
 
 			imageIDs[secondImage.ID] = struct{}{}
 
-			Expect(secondImage.Buildpacks).To(HaveLen(3))
-			Expect(secondImage.Buildpacks[1].Key).To(Equal(settings.Buildpack.ID))
-			Expect(secondImage.Buildpacks[1].Layers).To(HaveKey("node"))
+			Expect(secondImage.Buildpacks).To(HaveLen(2))
+			Expect(secondImage.Buildpacks[0].Key).To(Equal(settings.Buildpack.ID))
+			Expect(secondImage.Buildpacks[0].Layers).To(HaveKey("node"))
 
 			Expect(logs).To(ContainLines(
 				fmt.Sprintf("%s 1.2.3", settings.Buildpack.Name),
@@ -347,7 +350,7 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(content).To(ContainSubstring("hello world"))
 
-			Expect(secondImage.Buildpacks[1].Layers["node"].SHA).NotTo(Equal(firstImage.Buildpacks[1].Layers["node"].SHA))
+			Expect(secondImage.Buildpacks[0].Layers["node"].SHA).NotTo(Equal(firstImage.Buildpacks[0].Layers["node"].SHA))
 		})
 	})
 }

--- a/integration/simple_app_test.go
+++ b/integration/simple_app_test.go
@@ -83,6 +83,19 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 				Expect(err).ToNot(HaveOccurred(), logs.String)
 
 				Expect(logs).To(ContainLines(
+					MatchRegexp(`    Selected CPython version \(using \): \d+\.\d+\.\d+`),
+				))
+				Expect(logs).To(ContainLines(
+					"  Executing build process",
+					MatchRegexp(`    Installing CPython \d+\.\d+\.\d+`),
+					MatchRegexp(`      Completed in \d+(\.\d+)?`),
+				))
+
+				Expect(logs).To(ContainLines(
+					"  Generating SBOM for /layers/paketo-buildpacks_cpython/cpython",
+				))
+
+				Expect(logs).To(ContainLines(
 					fmt.Sprintf("%s 1.2.3", settings.Buildpack.Name),
 					"  Resolving Node Engine version",
 					"    Candidate version sources (in priority order):",
@@ -184,10 +197,10 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 					WithPullPolicy("never").
 					WithEnv(map[string]string{"NODE_ENV": "development", "NODE_VERBOSE": "true"}).
 					WithBuildpacks(
-						settings.Buildpacks.Cpython.Online,
 						settings.Buildpacks.NodeEngine.Online,
 						settings.Buildpacks.BuildPlan.Online,
 					).
+					WithEnv(map[string]string{"BP_NODE_EXCLUDE_BUILD_PYTHON": ""}).
 					Execute(name, source)
 				Expect(err).ToNot(HaveOccurred(), logs.String)
 
@@ -250,10 +263,10 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 				image, logs, err = pack.WithNoColor().Build.
 					WithPullPolicy("never").
 					WithBuildpacks(
-						settings.Buildpacks.Cpython.Online,
 						settings.Buildpacks.NodeEngine.Online,
 						settings.Buildpacks.BuildPlan.Online,
 					).
+					WithEnv(map[string]string{"BP_NODE_EXCLUDE_BUILD_PYTHON": ""}).
 					Execute(name, source)
 				Expect(err).ToNot(HaveOccurred(), logs.String)
 
@@ -337,10 +350,10 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 				image, logs, err = pack.WithNoColor().Build.
 					WithPullPolicy("never").
 					WithBuildpacks(
-						settings.Buildpacks.Cpython.Online,
 						settings.Buildpacks.NodeEngine.Online,
 						settings.Buildpacks.BuildPlan.Online,
 					).
+					WithEnv(map[string]string{"BP_NODE_EXCLUDE_BUILD_PYTHON": ""}).
 					Execute(name, source)
 				Expect(err).ToNot(HaveOccurred(), logs.String)
 
@@ -419,10 +432,10 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 				image, logs, err = pack.WithNoColor().Build.
 					WithPullPolicy("never").
 					WithBuildpacks(
-						settings.Buildpacks.Cpython.Online,
 						settings.Buildpacks.NodeEngine.Deprecated,
 						settings.Buildpacks.BuildPlan.Online,
 					).
+					WithEnv(map[string]string{"BP_NODE_EXCLUDE_BUILD_PYTHON": ""}).
 					Execute(name, source)
 				Expect(err).ToNot(HaveOccurred(), logs.String)
 
@@ -448,14 +461,14 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 				image, logs, err = pack.WithNoColor().Build.
 					WithPullPolicy("never").
 					WithBuildpacks(
-						settings.Buildpacks.Cpython.Online,
 						settings.Buildpacks.NodeEngine.Online,
 						settings.Buildpacks.BuildPlan.Online,
 					).
 					WithSBOMOutputDir(sbomDir).
 					WithEnv(map[string]string{
-						"BP_LOG_LEVEL":    "DEBUG",
-						"BP_DISABLE_SBOM": "true",
+						"BP_LOG_LEVEL":                 "DEBUG",
+						"BP_DISABLE_SBOM":              "true",
+						"BP_NODE_EXCLUDE_BUILD_PYTHON": "",
 					}).
 					Execute(name, source)
 				Expect(err).ToNot(HaveOccurred(), logs.String)


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR:
* introduces a new env variable called `BP_NODE_EXCLUDE_BUILD_PYTHON` where if is added, will not add the cpython buildpack even if the system does not have the python on the build image, hence no python will be installed on the build image.
 
## Use Cases
<!-- An explanation of the use cases your change enables -->

## Related issue 
* https://github.com/paketo-buildpacks/node-engine/issues/1329

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
