### PR TITLE
Revert "Requiring python during build time in case is not available on the build image"

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -1,9 +1,8 @@
 package nodeengine
 
 const (
-	Node    = "node"
-	Npm     = "npm"
-	Cpython = "cpython"
+	Node = "node"
+	Npm  = "npm"
 
 	DepKey             = "dependency-sha"
 	BuildKey           = "build"

--- a/detect.go
+++ b/detect.go
@@ -2,7 +2,6 @@ package nodeengine
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
 
 	"github.com/paketo-buildpacks/packit/v2"
@@ -17,8 +16,6 @@ type VersionParser interface {
 type BuildPlanMetadata struct {
 	Version       string `toml:"version"`
 	VersionSource string `toml:"version-source"`
-	Build         bool   `toml:"build"`
-	Launch        bool   `toml:"launch"`
 }
 
 func Detect(nvmrcParser, nodeVersionParser VersionParser) packit.DetectFunc {
@@ -79,20 +76,6 @@ func Detect(nvmrcParser, nodeVersionParser VersionParser) packit.DetectFunc {
 				Metadata: BuildPlanMetadata{
 					Version:       version,
 					VersionSource: NodeVersionSource,
-				},
-			})
-		}
-
-		targetOs := os.Getenv("CNB_TARGET_DISTRO_NAME")
-		_, pythonNotFound := exec.LookPath("python")
-
-		installPython := (targetOs != "rhel" && pythonNotFound != nil)
-		if installPython {
-			requirements = append(requirements, packit.BuildPlanRequirement{
-				Name: Cpython,
-				Metadata: BuildPlanMetadata{
-					Build:  true,
-					Launch: false,
 				},
 			})
 		}

--- a/integration.json
+++ b/integration.json
@@ -1,6 +1,7 @@
 {
   "build-plan": "github.com/paketo-community/build-plan",
   "builders": [
-    "index.docker.io/paketobuildpacks/builder-jammy-buildpackless-base:latest"
+    "index.docker.io/paketobuildpacks/builder-jammy-buildpackless-base:latest",
+    "index.docker.io/paketobuildpacks/ubuntu-noble-builder-buildpackless:latest"
   ]
 }

--- a/integration.json
+++ b/integration.json
@@ -1,8 +1,6 @@
 {
   "build-plan": "github.com/paketo-community/build-plan",
   "builders": [
-    "index.docker.io/paketobuildpacks/builder-jammy-buildpackless-base:latest",
-    "index.docker.io/paketobuildpacks/ubuntu-noble-builder-buildpackless:latest"
-  ],
-  "cpython": "github.com/paketo-buildpacks/cpython"
+    "index.docker.io/paketobuildpacks/builder-jammy-buildpackless-base:latest"
+  ]
 }

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -29,10 +29,6 @@ var settings struct {
 		Processes struct {
 			Online string
 		}
-		Cpython struct {
-			Online  string
-			Offline string
-		}
 	}
 
 	Buildpack struct {
@@ -42,7 +38,6 @@ var settings struct {
 
 	Config struct {
 		BuildPlan string `json:"build-plan"`
-		Cpython   string `json:"cpython"`
 	}
 }
 
@@ -77,15 +72,6 @@ func TestIntegration(t *testing.T) {
 		WithVersion("1.2.3").
 		Execute(root)
 	Expect(err).NotTo(HaveOccurred())
-
-	settings.Buildpacks.Cpython.Online, err = buildpackStore.Get.
-		Execute(settings.Config.Cpython)
-	Expect(err).ToNot(HaveOccurred())
-
-	settings.Buildpacks.Cpython.Offline, err = buildpackStore.Get.
-		WithOfflineDependencies().
-		Execute(settings.Config.Cpython)
-	Expect(err).ToNot(HaveOccurred())
 
 	tmpBuildpackDir, err := os.MkdirTemp("", "node-engine-outdated-deps")
 	Expect(err).NotTo(HaveOccurred())

--- a/integration/inspector_test.go
+++ b/integration/inspector_test.go
@@ -52,7 +52,6 @@ func testInspector(t *testing.T, context spec.G, it spec.S) {
 		image, logs, err = pack.WithNoColor().Build.
 			WithPullPolicy("never").
 			WithBuildpacks(
-				settings.Buildpacks.Cpython.Online,
 				settings.Buildpacks.NodeEngine.Online,
 				settings.Buildpacks.Processes.Online,
 			).

--- a/integration/offline_test.go
+++ b/integration/offline_test.go
@@ -56,7 +56,6 @@ func testOffline(t *testing.T, context spec.G, it spec.S) {
 			image, logs, err = pack.WithNoColor().Build.
 				WithPullPolicy("never").
 				WithBuildpacks(
-					settings.Buildpacks.Cpython.Offline,
 					settings.Buildpacks.NodeEngine.Offline,
 					settings.Buildpacks.BuildPlan.Online,
 				).

--- a/integration/openssl_test.go
+++ b/integration/openssl_test.go
@@ -67,7 +67,6 @@ func testOpenSSL(t *testing.T, context spec.G, it spec.S) {
 
 				image, logs, err = pack.WithNoColor().Build.
 					WithBuildpacks(
-						settings.Buildpacks.Cpython.Online,
 						settings.Buildpacks.NodeEngine.Online,
 						settings.Buildpacks.BuildPlan.Online,
 					).
@@ -107,7 +106,6 @@ func testOpenSSL(t *testing.T, context spec.G, it spec.S) {
 
 				image, logs, err = pack.WithNoColor().Build.
 					WithBuildpacks(
-						settings.Buildpacks.Cpython.Online,
 						settings.Buildpacks.NodeEngine.Online,
 						settings.Buildpacks.BuildPlan.Online,
 					).

--- a/integration/optimize_memory_test.go
+++ b/integration/optimize_memory_test.go
@@ -53,7 +53,6 @@ func testOptimizeMemory(t *testing.T, context spec.G, it spec.S) {
 		image, logs, err = pack.WithNoColor().Build.
 			WithPullPolicy("never").
 			WithBuildpacks(
-				settings.Buildpacks.Cpython.Online,
 				settings.Buildpacks.NodeEngine.Online,
 				settings.Buildpacks.Processes.Online,
 			).

--- a/integration/project_path_test.go
+++ b/integration/project_path_test.go
@@ -60,7 +60,6 @@ func testProjectPath(t *testing.T, context spec.G, it spec.S) {
 			image, logs, err = pack.WithNoColor().Build.
 				WithPullPolicy("never").
 				WithBuildpacks(
-					settings.Buildpacks.Cpython.Online,
 					settings.Buildpacks.NodeEngine.Online,
 					settings.Buildpacks.BuildPlan.Online,
 				).

--- a/integration/provides_test.go
+++ b/integration/provides_test.go
@@ -55,7 +55,6 @@ func testProvides(t *testing.T, context spec.G, it spec.S) {
 			image, logs, err = pack.WithNoColor().Build.
 				WithPullPolicy("never").
 				WithBuildpacks(
-					settings.Buildpacks.Cpython.Online,
 					settings.Buildpacks.NodeEngine.Online,
 					settings.Buildpacks.BuildPlan.Online,
 				).

--- a/integration/reuse_layer_rebuild_test.go
+++ b/integration/reuse_layer_rebuild_test.go
@@ -72,7 +72,6 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			firstImage, logs, err = pack.WithNoColor().Build.
 				WithPullPolicy("never").
 				WithBuildpacks(
-					settings.Buildpacks.Cpython.Online,
 					settings.Buildpacks.NodeEngine.Online,
 					settings.Buildpacks.BuildPlan.Online,
 				).
@@ -81,10 +80,9 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 
 			imageIDs[firstImage.ID] = struct{}{}
 
-
-			Expect(firstImage.Buildpacks).To(HaveLen(3))
-			Expect(firstImage.Buildpacks[1].Key).To(Equal(settings.Buildpack.ID))
-			Expect(firstImage.Buildpacks[1].Layers).To(HaveKey("node"))
+			Expect(firstImage.Buildpacks).To(HaveLen(2))
+			Expect(firstImage.Buildpacks[0].Key).To(Equal(settings.Buildpack.ID))
+			Expect(firstImage.Buildpacks[0].Layers).To(HaveKey("node"))
 
 			Expect(logs).To(ContainLines(
 				fmt.Sprintf("%s 1.2.3", settings.Buildpack.Name),
@@ -139,7 +137,6 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			secondImage, logs, err = pack.WithNoColor().Build.
 				WithPullPolicy("never").
 				WithBuildpacks(
-					settings.Buildpacks.Cpython.Online,
 					settings.Buildpacks.NodeEngine.Online,
 					settings.Buildpacks.BuildPlan.Online,
 				).
@@ -148,9 +145,9 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 
 			imageIDs[secondImage.ID] = struct{}{}
 
-			Expect(secondImage.Buildpacks).To(HaveLen(3))
-			Expect(secondImage.Buildpacks[1].Key).To(Equal(settings.Buildpack.ID))
-			Expect(secondImage.Buildpacks[1].Layers).To(HaveKey("node"))
+			Expect(secondImage.Buildpacks).To(HaveLen(2))
+			Expect(secondImage.Buildpacks[0].Key).To(Equal(settings.Buildpack.ID))
+			Expect(secondImage.Buildpacks[0].Layers).To(HaveKey("node"))
 
 			Expect(logs).To(ContainLines(
 				fmt.Sprintf("%s 1.2.3", settings.Buildpack.Name),
@@ -184,8 +181,7 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(content).To(ContainSubstring("hello world"))
 
-			Expect(secondImage.Buildpacks[0].Layers["cpython"].SHA).To(Equal(firstImage.Buildpacks[0].Layers["cpython"].SHA))
-			Expect(secondImage.Buildpacks[1].Layers["node"].SHA).To(Equal(firstImage.Buildpacks[1].Layers["node"].SHA))
+			Expect(secondImage.Buildpacks[0].Layers["node"].SHA).To(Equal(firstImage.Buildpacks[0].Layers["node"].SHA))
 		})
 	})
 
@@ -207,7 +203,6 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			firstImage, logs, err = pack.WithNoColor().Build.
 				WithPullPolicy("never").
 				WithBuildpacks(
-					settings.Buildpacks.Cpython.Online,
 					settings.Buildpacks.NodeEngine.Online,
 					settings.Buildpacks.BuildPlan.Online,
 				).
@@ -217,9 +212,9 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 
 			imageIDs[firstImage.ID] = struct{}{}
 
-			Expect(firstImage.Buildpacks).To(HaveLen(3))
-			Expect(firstImage.Buildpacks[1].Key).To(Equal(settings.Buildpack.ID))
-			Expect(firstImage.Buildpacks[1].Layers).To(HaveKey("node"))
+			Expect(firstImage.Buildpacks).To(HaveLen(2))
+			Expect(firstImage.Buildpacks[0].Key).To(Equal(settings.Buildpack.ID))
+			Expect(firstImage.Buildpacks[0].Layers).To(HaveKey("node"))
 
 			Expect(logs).To(ContainLines(
 				fmt.Sprintf("%s 1.2.3", settings.Buildpack.Name),
@@ -275,7 +270,6 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			secondImage, logs, err = pack.WithNoColor().Build.
 				WithPullPolicy("never").
 				WithBuildpacks(
-					settings.Buildpacks.Cpython.Online,
 					settings.Buildpacks.NodeEngine.Online,
 					settings.Buildpacks.BuildPlan.Online,
 				).
@@ -285,9 +279,9 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 
 			imageIDs[secondImage.ID] = struct{}{}
 
-			Expect(secondImage.Buildpacks).To(HaveLen(3))
-			Expect(secondImage.Buildpacks[1].Key).To(Equal(settings.Buildpack.ID))
-			Expect(secondImage.Buildpacks[1].Layers).To(HaveKey("node"))
+			Expect(secondImage.Buildpacks).To(HaveLen(2))
+			Expect(secondImage.Buildpacks[0].Key).To(Equal(settings.Buildpack.ID))
+			Expect(secondImage.Buildpacks[0].Layers).To(HaveKey("node"))
 
 			Expect(logs).To(ContainLines(
 				fmt.Sprintf("%s 1.2.3", settings.Buildpack.Name),
@@ -347,7 +341,7 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(content).To(ContainSubstring("hello world"))
 
-			Expect(secondImage.Buildpacks[1].Layers["node"].SHA).NotTo(Equal(firstImage.Buildpacks[1].Layers["node"].SHA))
+			Expect(secondImage.Buildpacks[0].Layers["node"].SHA).NotTo(Equal(firstImage.Buildpacks[0].Layers["node"].SHA))
 		})
 	})
 }

--- a/integration/simple_app_test.go
+++ b/integration/simple_app_test.go
@@ -71,7 +71,6 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 				image, logs, err = pack.WithNoColor().Build.
 					WithPullPolicy("never").
 					WithBuildpacks(
-						settings.Buildpacks.Cpython.Online,
 						settings.Buildpacks.NodeEngine.Online,
 						settings.Buildpacks.BuildPlan.Online,
 					).
@@ -184,7 +183,6 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 					WithPullPolicy("never").
 					WithEnv(map[string]string{"NODE_ENV": "development", "NODE_VERBOSE": "true"}).
 					WithBuildpacks(
-						settings.Buildpacks.Cpython.Online,
 						settings.Buildpacks.NodeEngine.Online,
 						settings.Buildpacks.BuildPlan.Online,
 					).
@@ -250,7 +248,6 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 				image, logs, err = pack.WithNoColor().Build.
 					WithPullPolicy("never").
 					WithBuildpacks(
-						settings.Buildpacks.Cpython.Online,
 						settings.Buildpacks.NodeEngine.Online,
 						settings.Buildpacks.BuildPlan.Online,
 					).
@@ -337,7 +334,6 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 				image, logs, err = pack.WithNoColor().Build.
 					WithPullPolicy("never").
 					WithBuildpacks(
-						settings.Buildpacks.Cpython.Online,
 						settings.Buildpacks.NodeEngine.Online,
 						settings.Buildpacks.BuildPlan.Online,
 					).
@@ -419,7 +415,6 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 				image, logs, err = pack.WithNoColor().Build.
 					WithPullPolicy("never").
 					WithBuildpacks(
-						settings.Buildpacks.Cpython.Online,
 						settings.Buildpacks.NodeEngine.Deprecated,
 						settings.Buildpacks.BuildPlan.Online,
 					).
@@ -448,7 +443,6 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 				image, logs, err = pack.WithNoColor().Build.
 					WithPullPolicy("never").
 					WithBuildpacks(
-						settings.Buildpacks.Cpython.Online,
 						settings.Buildpacks.NodeEngine.Online,
 						settings.Buildpacks.BuildPlan.Online,
 					).


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
* Reverts paketo-buildpacks/node-engine#1318 based on the discussion https://github.com/paketo-buildpacks/node-engine/issues/1329

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Related issue
https://github.com/paketo-buildpacks/node-engine/issues/1329


## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).